### PR TITLE
Add `--action=parse` report and misc fixes.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,11 @@
 History
 =======
 
+## Current
+
+* Add `--action=parse` report.
+  [#7](https://github.com/FormidableLabs/inspectpack/issues/7)
+
 ## 0.3.0
 
 * Add `--action=files` report.

--- a/README.md
+++ b/README.md
@@ -25,16 +25,19 @@ An inspection tool for Webpack frontend JavaScript bundles.
 Usage: inspectpack --action=<string> [options]
 
 Options:
-  --action, -a        Actions to take[string] [required] [choices: "duplicates", "pattern", "files"]
+  --action, -a        Actions to take
+                            [string] [required] [choices: "duplicates", "files", "parse", "pattern"]
   --bundle, -b        Path to webpack-created JS bundle                                     [string]
   --format, -f        Display output format     [string] [choices: "json", "text"] [default: "text"]
   --verbose           Verbose output                                      [boolean] [default: false]
   --minified, -m      Calculate / display minified byte sizes              [boolean] [default: true]
   --gzip, -g          Calculate / display minified + gzipped byte size (implies `--minified`)
                                                                            [boolean] [default: true]
-  --pattern, -p       Regular expression strings to match on                   [array] [default: []]
-  --suspect-patterns  Known 'suspicious' patterns for `--pattern`                          [boolean]
-  --suspect-files     Known 'suspicious' file names for `--files`                          [boolean]
+  --pattern, -p       Regular expression string(s) to match on                 [array] [default: []]
+  --path              Path to input file(s)                                    [array] [default: []]
+  --suspect-patterns  Known 'suspicious' patterns for `--action=pattern`                   [boolean]
+  --suspect-parses    Known 'suspicious' code parses for `--action=parse`                  [boolean]
+  --suspect-files     Known 'suspicious' file names for `--action=files`                   [boolean]
   --help, -h          Show help                                                            [boolean]
   --version, -v       Show version number                                                  [boolean]
 
@@ -42,6 +45,8 @@ Examples:
   inspectpack --action=duplicates --bundle=bundle.js  Report duplicates that cannot be deduped
   inspectpack --action=pattern --bundle=bundle.js     Show files with pattern matches in code
   --suspect-patterns
+  inspectpack --action=parse --bundle=bundle.js       Show files with parse function matches in code
+  --suspect-parses
   inspectpack --action=files --bundle=bundle.js       Show files with pattern matches in file names
   --suspect-files
 ```
@@ -243,7 +248,6 @@ in the option `--suspect-files`.
 
 First create a [bundle](#bundle). Then run:
 
-
 ```sh
 # A single file pattern
 $ inspectpack \
@@ -322,6 +326,18 @@ inspectpack --action=files
     * Refs:
         * 2855: ../~/moment/locale ^\.\/.*$
 ```
+
+### `parse`
+
+Detect the occurrence of 1+ code transform matches in code sections of the
+bundle. This is another means of detecting anti-patterns, some of which we
+aggregate in `--suspect-parses`.
+
+First create a [bundle](#bundle). Then run:
+
+**TODO: WRITE_REST_OF_PARSE_SECTION**
+
+**TODO: DOCUMENT_AND_TEST_PATH_OPTION**
 
 
 ## Other Useful Tools

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -3,8 +3,9 @@
 var ACTIONS = {
   /*eslint-disable global-require*/
   duplicates: require("./actions/duplicates"),
-  files: require("./actions/files"),
-  pattern: require("./actions/pattern")
+  pattern: require("./actions/pattern"),
+  parse: require("./actions/parse"),
+  files: require("./actions/files")
   /*eslint-enable global-require*/
 };
 

--- a/lib/actions/duplicates.js
+++ b/lib/actions/duplicates.js
@@ -8,18 +8,9 @@ var uglify = require("uglify-js");
 
 var Base = require("./base");
 var metaSum = require("../utils/data").metaSum;
+var toParseable = require("../utils/code").toParseable;
 
 var GZIP_OPTS = { level: 9 };
-
-// Helper: Prep code source for minification.
-var _getCodeSource = function (codes, idx) {
-  // Uglify doesn't like raw functions like:
-  // `function(module, exports, __webpack_require__) {}` -> `undefined`,
-  // so we prepend a variable to make it happy:
-  // `a=function(module, exports, __webpack_require__) {}` -> `a=function(a,b,c){};`,
-  var pad = "a=";
-  return pad + codes[idx].code.trim().replace(/,$/, "");
-};
 
 /**
  * Add full, minified, gzipped size data points.
@@ -47,7 +38,7 @@ var addSizes = function (codes, opts) {
     // Update summary items.
     _.each(function (obj, idx) {
       // Mutate sizes.
-      var codeSrc = _getCodeSource(codes, idx);
+      var codeSrc = toParseable(codes[idx].code);
       var fullSize = codeSrc.length;
       var minSrc = minified ? uglify.minify(codeSrc, { fromString: true }).code : null;
       var minSize = minified ? minSrc.length : "--";

--- a/lib/actions/parse.js
+++ b/lib/actions/parse.js
@@ -3,11 +3,76 @@
 var util = require("util");
 var _ = require("lodash/fp");
 var objMap = require("lodash/map"); // TODO GLOBAL: Unwind this with global config.
-var babylon = require("babylon");
+var parse = require("babylon").parse;
+var traverse = require("babel-traverse").default;
+var t = require("babel-types");
 
 var Base = require("./base");
 var metaSum = require("../utils/data").metaSum;
 var toParseable = require("../utils/code").toParseable;
+
+
+function isExports (node) {
+  return t.isIdentifier(node) && t.name === "exports";
+}
+
+function isModuleExports(node) {
+  return t.isMemberExpression(node) &&
+    t.isIdentifier(node.object) &&
+    t.isIdentifier(node.property) &&
+    node.object.name === "module" &&
+    node.property.name === "exports";
+}
+
+function isExportsSubproperty (node) {
+  if (!node.object) { return false; }
+
+  return isExports(node.object) ||
+    isModuleExports(node.object) ||
+    // module.exports.foo.something
+    isExportsSubproperty(node.object);
+}
+
+function isWebpackRequire (node) {
+  return t.isCallExpression(node) &&
+    t.isIdentifier(node.callee) &&
+    node.callee.name === "__webpack_require__";
+}
+
+function getReExportedModules (moduleAst) {
+  var otherModuleReferences = Object.create(null);
+
+  traverse(moduleAst, {
+    noScope: true,
+    AssignmentExpression: function (path) {
+      var node = path.node;
+
+      if (
+      // module.exports.foo.something = __webpack_require__(4);
+      // module.exports.foo = __webpack_require__(4);
+        isExportsSubproperty(node.left) &&
+        isWebpackRequire(node.right)
+      ) {
+        otherModuleReferences[node.right.arguments[0].value] = true;
+      } else if (
+      // module.exports = { foo: __webpack_require__(4) };          
+        t.isObjectExpression(node.right) &&
+        isModuleExports(node.left)
+      ) {
+        _.each(function (objectProperty) {
+          if (isWebpackRequire(objectProperty.value)) {
+            otherModuleReferences[objectProperty.value.arguments[0].value] = true;
+          }
+        })(node.right.properties);
+      }
+    }
+
+  });
+
+  // Don't report two re-exported values if they both come from the same
+  // imported module.
+  return _.keys(otherModuleReferences).length;
+}
 
 /**
  * Suspect parse functions.
@@ -15,15 +80,6 @@ var toParseable = require("../utils/code").toParseable;
  * For `--suspect-parses`.
  */
 var SUSPECT_PARSES = {
-  // TODO: REMOVE - This is a regex version of a single type of multiple exports detection.
-  MULTIPLE_EXPORT_RE_TEMP: function (src) {
-    var re = new RegExp(
-      "[^\\n]*(module\\\.|)exports\\\s*=\\\s*\{(\\\s*.*__webpack_require__\\(.*){2}");
-    var match = src.match(re);
-
-    return match ? match[0] : null; // eslint-disable-line no-magic-numbers
-  },
-
   // Multiple Exports.
   //
   // ```js
@@ -38,30 +94,8 @@ var SUSPECT_PARSES = {
   // module.exports.bar = __webpack_require__(2);
   // ```
   MULTIPLE_EXPORT: function (src) {
-    var ast = babylon.parse(src, {
-      sourceType: "module"
-    });
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Holla Babel Experts!
-    // --------------------
-    // Right here we'd like to handle at least the first three `a`, `b`, `c`
-    // of https://gist.github.com/ryan-roemer/c2b507ef0e17c392b9f09b7a03e1371c
-    // and _if possible_, the stretch goal of `d`.
-    //
-    // This function simply needs to return `true` if there is a multiple
-    // export match.
-    //
-    // After this section is done, please remove `MULTIPLE_EXPORT_RE_TEMP`
-    // above which gives a regex version of one of our scenarios as a guide
-    // for how things should work.
-    //
-    // THANKS!
-    ///////////////////////////////////////////////////////////////////////////
-    console.log("TODO HERE AST", JSON.stringify(ast, null, 2)); // eslint-disable-line
-    ///////////////////////////////////////////////////////////////////////////
-
-    return false;
+    var ast = parse(src, { sourceType: "module" });
+    return getReExportedModules(ast) > 1;
   }
 };
 

--- a/lib/actions/parse.js
+++ b/lib/actions/parse.js
@@ -173,7 +173,7 @@ Parse.prototype.textTemplate = _.template([
   "<% })(obj.refs); %><% } %>",
   "        * Matches: <%= obj.matches.length %>",
   "<% _.each(function (m) { %>" +
-  "            * <%= m.key %> - TODO_REMOVED_PATTERN:",
+  "            * <%= m.key %>:",
   "<%= _.map(function (l) { return '              ' + l; })(m.match.split('\\n')).join('\\n') %>",
   "<% })(obj.matches); %>",
   "<% })((meta || meta.meta).summary); %>" + // Handle verbose.

--- a/lib/actions/parse.js
+++ b/lib/actions/parse.js
@@ -11,7 +11,7 @@ var Base = require("./base");
 var metaSum = require("../utils/data").metaSum;
 var toParseable = require("../utils/code").toParseable;
 
-
+// Parse helpers
 var isExports = function (node) {
   return t.isIdentifier(node) && t.name === "exports";
 };
@@ -40,7 +40,7 @@ var isWebpackRequire = function (node) {
 };
 
 var getReExportedReferences = function (moduleAst) {
-  var otherModuleReferences = Object.create(null);
+  var otherModuleReferences = {};
 
   traverse(moduleAst, {
     noScope: true,
@@ -48,39 +48,29 @@ var getReExportedReferences = function (moduleAst) {
       var node = path.node;
 
       if (
-      // module.exports.foo.something = __webpack_require__(4);
-      // module.exports.foo = __webpack_require__(4);
+        // module.exports.foo.something = __webpack_require__(4);
+        // module.exports.foo = __webpack_require__(4);
         isExportsSubproperty(node.left) &&
         isWebpackRequire(node.right)
       ) {
-        otherModuleReferences[node.right.arguments[0].value] = node.loc; // eslint-disable-line no-magic-numbers,max-len
+        // eslint-disable-next-line no-magic-numbers
+        otherModuleReferences[node.right.arguments[0].value] = node.loc;
       } else if (
-      // module.exports = { foo: __webpack_require__(4) };
+        // module.exports = { foo: __webpack_require__(4) };
         t.isObjectExpression(node.right) &&
         isModuleExports(node.left)
       ) {
         _.each(function (objectProperty) {
           if (isWebpackRequire(objectProperty.value)) {
-            otherModuleReferences[objectProperty.value.arguments[0].value] = node.right.loc; // eslint-disable-line no-magic-numbers,max-len
+            // eslint-disable-next-line no-magic-numbers
+            otherModuleReferences[objectProperty.value.arguments[0].value] = node.right.loc;
           }
         })(node.right.properties);
       }
     }
-
   });
 
   return otherModuleReferences;
-};
-
-var dedent = function (lines) {
-  var indentation = lines.reduce(function (memo, line) {
-    var lineIndent = /^ */.exec(line)[0].length; // eslint-disable-line no-magic-numbers
-    return lineIndent < memo ? lineIndent : memo;
-  }, Infinity);
-
-  return lines.map(function (line) {
-    return line.slice(indentation);
-  });
 };
 
 /**
@@ -102,29 +92,30 @@ var SUSPECT_PARSES = {
   // module.exports.foo = __webpack_require__(1);
   // module.exports.bar = __webpack_require__(2);
   // ```
-  MULTIPLE_EXPORT: function (src) {
+  MULTIPLE_EXPORTS: function (src) {
     var ast = parse(src, { sourceType: "module" });
     var reExportedReferences = getReExportedReferences(ast);
+    var snipped = "// ...";
 
+    // Check if we have one or less re-export (in which case we don't care.)
     if (_.keys(reExportedReferences).length < 2) { // eslint-disable-line no-magic-numbers
       return false;
     }
 
+    // Create a truncated version of output text with _just_ the re-export
+    // matches
     var srcLines = src.split("\n");
 
     var snippets = _.flow(
       _.values,
       _.uniqBy(_.identity),
-      _.map(function (location) {
-        return srcLines.slice(location.start.line - 1, location.end.line); // eslint-disable-line no-magic-numbers,max-len
+      _.map(function (loc) { // eslint-disable-next-line no-magic-numbers
+        return srcLines.slice(loc.start.line - 1, loc.end.line);
       }),
-      _.map(dedent),
-      _.map(function (snippetLines) {
-        return snippetLines.join("\n");
-      })
+      _.map(function (lines) { return lines.join("\n"); })
     )(reExportedReferences);
 
-    return snippets.join("\n// ...\n");
+    return snippets.join("\n" + snipped + "\n");
   }
 };
 
@@ -143,7 +134,7 @@ Parse.prototype.name = "parse";
 
 Parse.prototype.textTemplate = _.template([
   "inspectpack --action=parse",
-  "============================",
+  "==========================",
   "",
   "## Summary",
   "",
@@ -186,7 +177,7 @@ Parse.prototype.getData = function (callback) {
   var bundle = this.bundle;
   var codes = bundle.codes;
 
-  // Inflate to regex objects of `{ [key], fn }`
+  // Inflate to objects of `{ [key], fn }`
   var parses = [].concat(
     // Suspect parses
     objMap(opts.suspectParses ? SUSPECT_PARSES : {}, function (fn, key) {
@@ -202,7 +193,7 @@ Parse.prototype.getData = function (callback) {
         key: fnPath,
         fn: require(fnPath) // eslint-disable-line global-require
       };
-    })(opts.paths)
+    })(opts.path)
   );
 
   // Create data object.
@@ -235,7 +226,6 @@ Parse.prototype.getData = function (callback) {
 
         // Map to final form and mutate summary: `{ [key], parse, match }`
         _.each(function (obj) {
-
           meta.summary[obj.index].matches = [].concat(
             meta.summary[obj.index].matches || [],
             [{

--- a/lib/actions/parse.js
+++ b/lib/actions/parse.js
@@ -1,0 +1,227 @@
+"use strict";
+
+var util = require("util");
+var _ = require("lodash/fp");
+var objMap = require("lodash/map"); // TODO GLOBAL: Unwind this with global config.
+var babylon = require("babylon");
+
+var Base = require("./base");
+var metaSum = require("../utils/data").metaSum;
+var toParseable = require("../utils/code").toParseable;
+
+/**
+ * Suspect parse functions.
+ *
+ * For `--suspect-parses`.
+ */
+var SUSPECT_PARSES = {
+  // TODO: REMOVE - This is a regex version of a single type of multiple exports detection.
+  MULTIPLE_EXPORT_RE_TEMP: function (src) {
+    var re = new RegExp(
+      "[^\\n]*(module\\\.|)exports\\\s*=\\\s*\{(\\\s*.*__webpack_require__\\(.*){2}");
+    var match = src.match(re);
+
+    return match ? match[0] : null; // eslint-disable-line no-magic-numbers
+  },
+
+  // Multiple Exports.
+  //
+  // ```js
+  // // Single declaration
+  // module.exports = {
+  //   foo: __webpack_require__(1),
+  //   bar: __webpack_require__(2)
+  // }
+  //
+  // // Multiple declaration
+  // module.exports.foo = __webpack_require__(1);
+  // module.exports.bar = __webpack_require__(2);
+  // ```
+  MULTIPLE_EXPORT: function (src) {
+    var ast = babylon.parse(src, {
+      sourceType: "module"
+    });
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Holla Babel Experts!
+    // --------------------
+    // Right here we'd like to handle at least the first three `a`, `b`, `c`
+    // of https://gist.github.com/ryan-roemer/c2b507ef0e17c392b9f09b7a03e1371c
+    // and _if possible_, the stretch goal of `d`.
+    //
+    // This function simply needs to return `true` if there is a multiple
+    // export match.
+    //
+    // After this section is done, please remove `MULTIPLE_EXPORT_RE_TEMP`
+    // above which gives a regex version of one of our scenarios as a guide
+    // for how things should work.
+    //
+    // THANKS!
+    ///////////////////////////////////////////////////////////////////////////
+    console.log("TODO HERE AST", JSON.stringify(ast, null, 2)); // eslint-disable-line
+    ///////////////////////////////////////////////////////////////////////////
+
+    return false;
+  }
+};
+
+/**
+ * Parse action abstraction.
+ *
+ * @returns {void}
+ */
+var Parse = function Parse() {
+  Base.apply(this, arguments);
+};
+
+util.inherits(Parse, Base);
+
+Parse.prototype.name = "parse";
+
+Parse.prototype.textTemplate = _.template([
+  "inspectpack --action=parse",
+  "============================",
+  "",
+  "## Summary",
+  "",
+  "* Bundle:",
+  "    * Path:                <%= opts.bundle %>",
+  "    * Num Matches:         <%= meta.numMatches %>",
+  "    * Num Unique Files:    <%= meta.numUniqueFiles %>",
+  "    * Num All Files:       <%= meta.numAllFiles %>",
+  "    * Custom Parses:       <% _.each(function (key) { %>",
+  "        * <%= key %>" +
+  "<% })(opts.parse); %><% if (opts.suspectParses) { %>",
+  "    * Suspect Parses:      <% _.each(function (key) { %>",
+  "        * <%= key %>" +
+  "<% })(meta.suspectParses); %><% } %>",
+  "",
+  "## Matches",
+  "<% _.each(function (meta, fileName) { %>",
+  "* <%= fileName %>",
+  "    * Num Matches:         <%= meta.parse.numMatches %>",
+  "    * Num Files Matched:   <%= meta.parse.numFilesMatched %>",
+  "",
+  "<% _.each(function (obj, idx) { %>" +
+  "    * <%= idx %>: <%= obj.source %><% if (obj.refs.length) { %>",
+  "        * Files",
+  "<% _.each(function (ref) { %>" +
+  "            * <%= ref %>",
+  "<% })(obj.refs); %><% } %>",
+  "        * Matches: <%= obj.matches.length %>",
+  "<% _.each(function (m) { %>" +
+  "            * <%= m.key %> - TODO_REMOVED_PATTERN:",
+  "<%= _.map(function (l) { return '              ' + l; })(m.match.split('\\n')).join('\\n') %>",
+  "<% })(obj.matches); %>",
+  "<% })((meta || meta.meta).summary); %>" + // Handle verbose.
+  "<% })(data); %>",
+  ""
+].join("\n"));
+
+Parse.prototype.getData = function (callback) {
+  var opts = this.opts;
+  var bundle = this.bundle;
+  var codes = bundle.codes;
+
+  // Inflate to regex objects of `{ [key], fn }`
+  var parses = [].concat(
+    // Suspect parses
+    objMap(opts.suspectParses ? SUSPECT_PARSES : {}, function (fn, key) {
+      return {
+        key: key,
+        fn: fn
+      };
+    }),
+
+    // Parse files from user
+    _.map(function (fnPath) {
+      return {
+        key: fnPath,
+        fn: require(fnPath) // eslint-disable-line global-require
+      };
+    })(opts.paths)
+  );
+
+  // Create data object.
+  var data = _.flow(
+    // Mutate summary with parse matches.
+    _.mapValues(function (group) {
+      var meta = group.meta;
+
+      // Stateful counters.
+      var numMatches = 0;
+
+      // Add matches, filter, and mutate summary.
+      _.flow(
+        // Map to match objects: `{ [key], fn, index, match }`
+        _.flatMap(function (obj) {
+          // Try to match for all unique indexes in play.
+          return _.flatMap(function (idx) {
+            return _.extend({
+              index: idx,
+              match: obj.fn(toParseable(codes[idx].code))
+            }, obj);
+          })(group.meta.uniqIdxs);
+        }),
+
+        // Only keep matches.
+        _.filter(function (obj) { return obj.match; }),
+
+        // Get number of matches.
+        _.tap(function (objs) { numMatches = objs.length; }),
+
+        // Map to final form and mutate summary: `{ [key], parse, match }`
+        _.each(function (obj) {
+
+          meta.summary[obj.index].matches = [].concat(
+            meta.summary[obj.index].matches || [],
+            [{
+              key: obj.key,
+              match: obj.match
+            }]
+          );
+        })
+      )(parses);
+
+      // Mutate summary to remove _unmatched_ indexes.
+      meta.summary = _.pickBy(function (val) { return !!val.matches; })(meta.summary);
+
+      // Add parses data.
+      meta.parse = {
+        numMatches: numMatches,
+        numFilesMatched: _.keys(meta.summary).length
+      };
+
+      return group;
+    }),
+
+    // Filter to 1+ matches.
+    _.pickBy(function (g) { return !!g.meta.parse.numMatches; }),
+
+    // Filter to just `meta` unless verbose.
+    _.mapValues(function (g) { return opts.verbose ? g : g.meta; })
+  )(bundle.groups);
+
+  // Metadata
+  data.meta = {
+    numMatches: metaSum("parse.numMatches")(data),
+    numUniqueFiles: _.keys(data).length,
+    numAllFiles: metaSum("parse.numFilesMatched")(data),
+    suspectParses: _.keys(SUSPECT_PARSES)
+  };
+
+  callback(null, data);
+};
+
+/**
+ * Return list of files matching 1+ parses.
+ *
+ * @param {Object}    opts                  Options
+ * @param {String}    opts.bundle           Bundle file path
+ * @param {Array}     opts.parse            1+ file paths to parse functions
+ * @param {Boolean}   opts.suspectParses    Use suspect parses enum
+ * @param {String}    opts.format           Output format type
+ * @param {Boolean}   opts.verbose          Verbose output?
+ * @returns {void}
+ */
+module.exports = Base.createWithBundle.bind(Parse);

--- a/lib/actions/parse.js
+++ b/lib/actions/parse.js
@@ -39,7 +39,7 @@ function isWebpackRequire (node) {
     node.callee.name === "__webpack_require__";
 }
 
-function getReExportedModules (moduleAst) {
+function getReExportedReferences (moduleAst) {
   var otherModuleReferences = Object.create(null);
 
   traverse(moduleAst, {
@@ -53,7 +53,7 @@ function getReExportedModules (moduleAst) {
         isExportsSubproperty(node.left) &&
         isWebpackRequire(node.right)
       ) {
-        otherModuleReferences[node.right.arguments[0].value] = true;
+        otherModuleReferences[node.right.arguments[0].value] = node.loc;
       } else if (
       // module.exports = { foo: __webpack_require__(4) };          
         t.isObjectExpression(node.right) &&
@@ -61,7 +61,7 @@ function getReExportedModules (moduleAst) {
       ) {
         _.each(function (objectProperty) {
           if (isWebpackRequire(objectProperty.value)) {
-            otherModuleReferences[objectProperty.value.arguments[0].value] = true;
+            otherModuleReferences[objectProperty.value.arguments[0].value] = node.right.loc;
           }
         })(node.right.properties);
       }
@@ -69,9 +69,18 @@ function getReExportedModules (moduleAst) {
 
   });
 
-  // Don't report two re-exported values if they both come from the same
-  // imported module.
-  return _.keys(otherModuleReferences).length;
+  return otherModuleReferences
+}
+
+function dedent (lines) {
+  var indentation = lines.reduce(function (memo, line) {
+    var lineIndent = /^ */.exec(line)[0].length;
+    return lineIndent < memo ? lineIndent : memo;
+  }, Infinity);
+
+  return lines.map(function (line) {
+    return line.slice(indentation);
+  });
 }
 
 /**
@@ -95,7 +104,27 @@ var SUSPECT_PARSES = {
   // ```
   MULTIPLE_EXPORT: function (src) {
     var ast = parse(src, { sourceType: "module" });
-    return getReExportedModules(ast) > 1;
+    var reExportedReferences = getReExportedReferences(ast);
+
+    if (_.keys(reExportedReferences).length < 2) {
+      return false;
+    }
+
+    var srcLines = src.split("\n");
+
+    var snippets = _.flow(
+      _.values,
+      _.uniqBy(_.identity),
+      _.map(function (location) {
+        return srcLines.slice(location.start.line - 1, location.end.line);
+      }),
+      _.map(dedent),
+      _.map(function (snippetLines) {
+        return snippetLines.join("\n");
+      })
+    )(reExportedReferences);
+
+    return snippets.join("\n// ...\n");
   }
 };
 

--- a/lib/actions/parse.js
+++ b/lib/actions/parse.js
@@ -12,34 +12,34 @@ var metaSum = require("../utils/data").metaSum;
 var toParseable = require("../utils/code").toParseable;
 
 
-function isExports (node) {
+var isExports = function (node) {
   return t.isIdentifier(node) && t.name === "exports";
-}
+};
 
-function isModuleExports(node) {
+var isModuleExports = function (node) {
   return t.isMemberExpression(node) &&
     t.isIdentifier(node.object) &&
     t.isIdentifier(node.property) &&
     node.object.name === "module" &&
     node.property.name === "exports";
-}
+};
 
-function isExportsSubproperty (node) {
+var isExportsSubproperty = function (node) {
   if (!node.object) { return false; }
 
   return isExports(node.object) ||
     isModuleExports(node.object) ||
     // module.exports.foo.something
     isExportsSubproperty(node.object);
-}
+};
 
-function isWebpackRequire (node) {
+var isWebpackRequire = function (node) {
   return t.isCallExpression(node) &&
     t.isIdentifier(node.callee) &&
     node.callee.name === "__webpack_require__";
-}
+};
 
-function getReExportedReferences (moduleAst) {
+var getReExportedReferences = function (moduleAst) {
   var otherModuleReferences = Object.create(null);
 
   traverse(moduleAst, {
@@ -53,15 +53,15 @@ function getReExportedReferences (moduleAst) {
         isExportsSubproperty(node.left) &&
         isWebpackRequire(node.right)
       ) {
-        otherModuleReferences[node.right.arguments[0].value] = node.loc;
+        otherModuleReferences[node.right.arguments[0].value] = node.loc; // eslint-disable-line no-magic-numbers,max-len
       } else if (
-      // module.exports = { foo: __webpack_require__(4) };          
+      // module.exports = { foo: __webpack_require__(4) };
         t.isObjectExpression(node.right) &&
         isModuleExports(node.left)
       ) {
         _.each(function (objectProperty) {
           if (isWebpackRequire(objectProperty.value)) {
-            otherModuleReferences[objectProperty.value.arguments[0].value] = node.right.loc;
+            otherModuleReferences[objectProperty.value.arguments[0].value] = node.right.loc; // eslint-disable-line no-magic-numbers,max-len
           }
         })(node.right.properties);
       }
@@ -69,19 +69,19 @@ function getReExportedReferences (moduleAst) {
 
   });
 
-  return otherModuleReferences
-}
+  return otherModuleReferences;
+};
 
-function dedent (lines) {
+var dedent = function (lines) {
   var indentation = lines.reduce(function (memo, line) {
-    var lineIndent = /^ */.exec(line)[0].length;
+    var lineIndent = /^ */.exec(line)[0].length; // eslint-disable-line no-magic-numbers
     return lineIndent < memo ? lineIndent : memo;
   }, Infinity);
 
   return lines.map(function (line) {
     return line.slice(indentation);
   });
-}
+};
 
 /**
  * Suspect parse functions.
@@ -106,7 +106,7 @@ var SUSPECT_PARSES = {
     var ast = parse(src, { sourceType: "module" });
     var reExportedReferences = getReExportedReferences(ast);
 
-    if (_.keys(reExportedReferences).length < 2) {
+    if (_.keys(reExportedReferences).length < 2) { // eslint-disable-line no-magic-numbers
       return false;
     }
 
@@ -116,7 +116,7 @@ var SUSPECT_PARSES = {
       _.values,
       _.uniqBy(_.identity),
       _.map(function (location) {
-        return srcLines.slice(location.start.line - 1, location.end.line);
+        return srcLines.slice(location.start.line - 1, location.end.line); // eslint-disable-line no-magic-numbers,max-len
       }),
       _.map(dedent),
       _.map(function (snippetLines) {

--- a/lib/args.js
+++ b/lib/args.js
@@ -6,6 +6,13 @@ var yargs = require("yargs");
 var TERMINAL_CHARS = 100;
 var NOT_FOUND = -1;
 
+var ACTIONS = [
+  "duplicates",
+  "files",
+  "parse",
+  "pattern"
+];
+
 /**
  * Validation wrapper
  *
@@ -27,13 +34,19 @@ Validate.prototype = {
   action: function () {
     var action = this.argv.action;
 
-    if (!this.argv.bundle && ["duplicates", "pattern", "files"].indexOf(action) === NOT_FOUND) {
+    if (!this.argv.bundle && ACTIONS.indexOf(action) === NOT_FOUND) {
       this._fail("Requires `--bundle` file");
     }
 
     if (action === "pattern") {
       if (!(this.argv.pattern.length || this.argv.suspectPatterns)) {
         this._fail("Requires 1+ `--pattern` strings or `--suspect-patterns`");
+      }
+    }
+
+    if (action === "parse") {
+      if (!(this.argv.path.length || this.argv.suspectParses)) {
+        this._fail("Requires 1+ `--path` paths or `--suspect-parses`");
       }
     }
 
@@ -58,7 +71,7 @@ module.exports = {
         alias: "a",
         describe: "Actions to take",
         type: "string",
-        choices: ["duplicates", "pattern", "files"],
+        choices: ACTIONS,
         required: true
       })
       .example(
@@ -68,6 +81,10 @@ module.exports = {
       .example(
         "inspectpack --action=pattern --bundle=bundle.js --suspect-patterns",
         "Show files with pattern matches in code"
+      )
+      .example(
+        "inspectpack --action=parse --bundle=bundle.js --suspect-parses",
+        "Show files with parse function matches in code"
       )
       .example(
         "inspectpack --action=files --bundle=bundle.js --suspect-files",
@@ -110,16 +127,25 @@ module.exports = {
       })
       .option("pattern", {
         alias: "p",
-        describe: "Regular expression strings to match on",
+        describe: "Regular expression string(s) to match on",
+        type: "array",
+        default: []
+      })
+      .option("path", {
+        describe: "Path to input file(s)",
         type: "array",
         default: []
       })
       .option("suspect-patterns", {
-        describe: "Known 'suspicious' patterns for `--pattern`",
+        describe: "Known 'suspicious' patterns for `--action=pattern`",
+        type: "boolean"
+      })
+      .option("suspect-parses", {
+        describe: "Known 'suspicious' code parses for `--action=parse`",
         type: "boolean"
       })
       .option("suspect-files", {
-        describe: "Known 'suspicious' file names for `--files`",
+        describe: "Known 'suspicious' file names for `--action=files`",
         type: "boolean"
       })
 

--- a/lib/models/bundle.js
+++ b/lib/models/bundle.js
@@ -291,7 +291,7 @@ Bundle.prototype.validate = function () {
 Bundle.prototype.SECTION_RE = /^\/\* ([0-9]+) \*\/[\,]?/gm;
 
 // Footer of webpack bundle.
-Bundle.prototype.FOOTER_TOKEN = "\n/******/ ])))";
+Bundle.prototype.FOOTER_TOKEN = "\n/******/ ])"; // Can have 1+ `)` instances.
 
 /**
  * Create array of code objects from raw code string.

--- a/lib/utils/code.js
+++ b/lib/utils/code.js
@@ -1,0 +1,33 @@
+"use strict";
+
+/**
+ * Code helpers.
+ */
+module.exports = {
+  /**
+   * Helper function to convert webpack functions to parseable code.
+   *
+   * Webpack gives us chunks like:
+   *
+   * ```js
+   * function(module, exports, __webpack_require__) {
+   *   // function body
+   * },
+   * ```
+   *
+   * Which parsers like Uglify and Babylon don't like. We add a prefix and
+   * truncate the trailing comma to produce:
+   *
+   * ```js
+   * a=function(module, exports, __webpack_require__) {
+   *   // function body
+   * }
+   * ```
+   *
+   * @param {String} src Source code
+   * @returns {String}   Parseable code
+   */
+  toParseable: function (src) {
+    return "a=" + src.trim().replace(/,$/, "");
+  }
+};

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "check": "npm run lint"
   },
   "dependencies": {
+    "babel-traverse": "^6.7.6",
+    "babel-types": "^6.7.2",
     "babylon": "^6.7.0",
     "lodash": "^4.6.1",
     "uglify-js": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "check": "npm run lint"
   },
   "dependencies": {
+    "babylon": "^6.7.0",
     "lodash": "^4.6.1",
     "uglify-js": "^2.6.2",
     "yargs": "^4.3.1"


### PR DESCRIPTION
* Add `--action=parse` report.
* Refactor args to better decompose actions.
* Update footer token removal for different webpack bundle types.
* Abstract `toParseable` utility.

## WIP - The babel transform

There's a conspicuous note of needing a babel function to return `true` for matching multiple exports (which we define as a `module.exports` field that is set from a `require()` of another file -- it's not _just_ multiple fields on `module.exports`).

I've got a sample simple bundle up at: https://gist.github.com/ryan-roemer/c2b507ef0e17c392b9f09b7a03e1371c that you can use to testing things out.

```sh
$ bin/inspectpack.js \
  --action=parse \
  --bundle="/PATH/TO/bundle.multiple-exports.js" \
  --format=text \
  --suspect-parses
```

Feel free to commit directly to the `SUSPECT_PARSES.MULTIPLE_EXPORT` function, or branch my branch -- whichever is easier. 

Thanks!

/cc @divmain @tptee