### PR TITLE
Parse es6 import export

### DIFF
--- a/lib/actions/parse.js
+++ b/lib/actions/parse.js
@@ -13,7 +13,7 @@ var toParseable = require("../utils/code").toParseable;
 
 // Parse helpers
 var isExports = function (node) {
-  return t.isIdentifier(node) && t.name === "exports";
+  return t.isIdentifier(node) && node.name === "exports";
 };
 
 var isModuleExports = function (node) {

--- a/lib/actions/parse.js
+++ b/lib/actions/parse.js
@@ -39,6 +39,34 @@ var isWebpackRequire = function (node) {
     node.callee.name === "__webpack_require__";
 };
 
+var isInteropCall = function (node) {
+  return t.isCallExpression(node) &&
+    t.isIdentifier(node.callee) &&
+    node.callee.name === "_interopRequireDefault";
+};
+
+var isAssignmentExpressionStmt = function (node) {
+  return t.isExpressionStatement(node) && t.isAssignmentExpression(node.expression);
+};
+
+var isEs6ModuleFlag = function (node) {
+  if (!isAssignmentExpressionStmt(node)) {
+    return false;
+  }
+
+  var left = node.expression.left;
+  var right = node.expression.right;
+
+  return node.expression.operator === "=" &&
+    t.isMemberExpression(left) &&
+    t.isIdentifier(left.object) &&
+    left.object.name === "exports" &&
+    t.isIdentifier(left.property) &&
+    left.property.name === "__esModule" &&
+    t.isBooleanLiteral(right) &&
+    right.value === true;
+};
+
 var getReExportedReferences = function (moduleAst) {
   var otherModuleReferences = {};
 
@@ -67,6 +95,53 @@ var getReExportedReferences = function (moduleAst) {
           }
         })(node.right.properties);
       }
+    }
+  });
+
+  return otherModuleReferences;
+};
+
+var getReExportedEs6References = function (moduleAst) {
+  var moduleBody = _.get("program.body[0].expression.right.body.body")(moduleAst);
+  var identifierToWebpackModule = {};
+  var otherModuleReferences = {};
+
+  var isEs6Module = false;
+  moduleBody.forEach(function (node) {
+    if (isEs6Module) {
+      if (
+        t.isVariableDeclaration(node) &&
+        node.declarations.length === 1 // eslint-disable-line no-magic-numbers
+      ) {
+        var decl = node.declarations[0]; // eslint-disable-line no-magic-numbers
+
+        if (isWebpackRequire(decl.init)) {
+          // var _thing = __webpack_require__(244);
+          // eslint-disable-next-line no-magic-numbers
+          identifierToWebpackModule[decl.id.name] = decl.init.arguments[0].value;
+        } else if (isInteropCall(decl.init)) {
+          // var _thing2 = _interopRequireDefault(_thing)
+          // eslint-disable-next-line no-magic-numbers
+          var unShimedIndentifierName = decl.init.arguments[0] && decl.init.arguments[0].name;
+          var webpackModule = identifierToWebpackModule[unShimedIndentifierName];
+          if (_.isNumber(webpackModule)) {
+            identifierToWebpackModule[decl.id.name] = webpackModule;
+          }
+        }
+      } else if (
+        // exports.thing = _thing2["default"];
+        isAssignmentExpressionStmt(node) &&
+        isExportsSubproperty(node.expression.left) &&
+        t.isMemberExpression(node.expression.right) &&
+        t.isIdentifier(node.expression.right.object) &&
+        node.expression.right.object.name in identifierToWebpackModule
+      ) {
+        webpackModule = identifierToWebpackModule[node.expression.right.object.name];
+        otherModuleReferences[webpackModule] = node.loc;
+      }
+    } else if (isEs6ModuleFlag(node)) {
+      // exports.__esModule = true;
+      isEs6Module = true;
     }
   });
 
@@ -119,6 +194,11 @@ var SUSPECT_PARSES = {
   MULTIPLE_EXPORTS: function (src) {
     var ast = parse(src, { sourceType: "module" });
     var reExportedReferences = getReExportedReferences(ast);
+    return getReExportedReferencesReport(src, reExportedReferences);
+  },
+  MULTIPLE_EXPORTS_ES: function (src) {
+    var ast = parse(src, { sourcetype: "module" });
+    var reExportedReferences = getReExportedEs6References(ast);
     return getReExportedReferencesReport(src, reExportedReferences);
   }
 };

--- a/lib/actions/parse.js
+++ b/lib/actions/parse.js
@@ -73,6 +73,30 @@ var getReExportedReferences = function (moduleAst) {
   return otherModuleReferences;
 };
 
+var getReExportedReferencesReport = function (src, reExportedReferences) {
+  var snipped = "// ...";
+
+  // Check if we have one or less re-export (in which case we don't care.)
+  if (_.keys(reExportedReferences).length < 2) { // eslint-disable-line no-magic-numbers
+    return false;
+  }
+
+  // Create a truncated version of output text with _just_ the re-export
+  // matches
+  var srcLines = src.split("\n");
+
+  var snippets = _.flow(
+    _.values,
+    _.uniqBy(_.identity),
+    _.map(function (loc) { // eslint-disable-next-line no-magic-numbers
+      return srcLines.slice(loc.start.line - 1, loc.end.line);
+    }),
+    _.map(function (lines) { return lines.join("\n"); })
+  )(reExportedReferences);
+
+  return snippets.join("\n" + snipped + "\n");
+};
+
 /**
  * Suspect parse functions.
  *
@@ -95,27 +119,7 @@ var SUSPECT_PARSES = {
   MULTIPLE_EXPORTS: function (src) {
     var ast = parse(src, { sourceType: "module" });
     var reExportedReferences = getReExportedReferences(ast);
-    var snipped = "// ...";
-
-    // Check if we have one or less re-export (in which case we don't care.)
-    if (_.keys(reExportedReferences).length < 2) { // eslint-disable-line no-magic-numbers
-      return false;
-    }
-
-    // Create a truncated version of output text with _just_ the re-export
-    // matches
-    var srcLines = src.split("\n");
-
-    var snippets = _.flow(
-      _.values,
-      _.uniqBy(_.identity),
-      _.map(function (loc) { // eslint-disable-next-line no-magic-numbers
-        return srcLines.slice(loc.start.line - 1, loc.end.line);
-      }),
-      _.map(function (lines) { return lines.join("\n"); })
-    )(reExportedReferences);
-
-    return snippets.join("\n" + snipped + "\n");
+    return getReExportedReferencesReport(src, reExportedReferences);
   }
 };
 


### PR DESCRIPTION
This addition satisfies the simple case of ES6 import/export as outlined in #14.  It does track variables through `_interopRequireDefault`, which may catch the simple case of destructured imports also.  It will not track module references through intermediate variables, although it works around issues with double-exports of the same import module.

@ryan-roemer 