### PR TITLE
BUG: Fix / update all `lodash/fp` use throughout.

### DIFF
--- a/.eslintrc-server
+++ b/.eslintrc-server
@@ -1,3 +1,10 @@
 ---
 extends:
+  - "plugin:lodash-fp/recommended"
   - "defaults/configurations/walmart/es5-node"
+
+plugins:
+  - lodash-fp
+
+rules:
+  strict: 0

--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ $ npm install inspectpack
 ## Usage
 
 ```
+An inspection tool for Webpack frontend JavaScript bundles.
+
 Usage: inspectpack --action=<string> [options]
 
 Options:
   --action, -a        Actions to take
-                [string] [required] [choices: "duplicates", "files", "versions", "pattern", "sizes"]
+       [string] [required] [choices: "duplicates", "pattern", "parse", "files", "versions", "sizes"]
   --bundle, -b        Path to webpack-created JS bundle                                     [string]
   --root, -r          Project root (for `node_modules` introspection, default cwd)          [string]
   --format, -f        Display output format

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -26,3 +26,6 @@ module.exports = function (name) {
 
   return action;
 };
+
+// Expose actions.
+module.exports.ACTIONS = ACTIONS;

--- a/lib/actions/duplicates.js
+++ b/lib/actions/duplicates.js
@@ -36,7 +36,7 @@ var addSizes = function (codes, opts) {
     var minMinGzSize = null;
 
     // Update summary items.
-    _.each(function (obj, idx) {
+    _.each.convert({ cap: false })(function (obj, idx) {
       // Mutate sizes.
       var codeSrc = toParseable(codes[idx].code);
       var fullSize = codeSrc.length;
@@ -112,7 +112,7 @@ Duplicates.prototype.textTemplate = _.template([
   " Math.round((meta.size.minGzExtra / meta.bundle.minGz) * 100) + ' %' : '--' %>",
   "",
   "## Duplicates:",
-  "<% _.each(function (meta, fileName) { %>",
+  "<% _.each.convert({ cap: false })(function (meta, fileName) { %>",
   "* <%= fileName %>",
   "    * Num Duplicates:          <%= meta.uniqIdxs.length %>",
   "    * Current Bytes (min):     <%= meta.size.min %>",
@@ -120,7 +120,7 @@ Duplicates.prototype.textTemplate = _.template([
   "    * Current Bytes (min+gz):  <%= meta.size.minGz %>",
   "    * Extra Bytes (min+gz):    <%= meta.size.minGzExtra %>",
   "",
-  "<% _.each(function (obj, idx) { %>" +
+  "<% _.each.convert({ cap: false })(function (obj, idx) { %>" +
   "    * <%= idx %> (<%= obj.refs.length %>): <%= obj.source %>",
   "<% _.each(function (ref) { %>" +
   "        * <%= ref %>",
@@ -132,7 +132,7 @@ Duplicates.prototype.textTemplate = _.template([
 
 Duplicates.prototype.tsvTemplate = _.template([
   "File\tDuplicates\tTotal Size (m)\tExtra Size (m)\tTotal Size (m+gz)\tExtra Size (m+gz)\n",
-  "<% _.each(function (meta, fileName) { %>",
+  "<% _.each.convert({ cap: false })(function (meta, fileName) { %>",
   "<%= fileName %>\t",
   "<%= meta.uniqIdxs.length %>\t",
   "<%= meta.size.min %>\t",

--- a/lib/actions/files.js
+++ b/lib/actions/files.js
@@ -2,7 +2,6 @@
 
 var util = require("util");
 var _ = require("lodash/fp");
-var objMap = require("lodash/map");
 
 var Base = require("./base");
 var metaSum = require("../utils/data").metaSum;
@@ -69,7 +68,7 @@ Files.prototype.textTemplate = _.template([
   "    * Custom Patterns:     <% _.each(function (pattern) { %>",
   "        * <%= pattern %>" +
   "<% })(opts.pattern); %><% if (opts.suspectFiles) { %>",
-  "    * Suspect Patterns:    <% _.each(function (pattern, key) { %>",
+  "    * Suspect Patterns:    <% _.each.convert({ cap: false })(function (pattern, key) { %>",
   "        * <%= key %>: <%= pattern %>" +
   "<% })(meta.suspectFiles); %><% } %>",
   "",
@@ -78,14 +77,14 @@ Files.prototype.textTemplate = _.template([
   "<% })(meta.matchedFiles); %>",
   "",
   "## Matches",
-  "<% _.each(function (meta, fileName) { %>",
+  "<% _.each.convert({ cap: false })(function (meta, fileName) { %>",
   "* <%= fileName %>",
   "    * Matches:            <%= (meta || meta.meta).files.numMatches %>",
   "<% _.each(function (m) { %>" +
   "        * <%= m.key || 'CUSTOM' %> - <%= m.pattern %>: <%= m.match %>",
   "<% })((meta || meta.meta).files.matches); %>" + // Handle verbose.
   "    * Refs:",
-  "<% _.each(function (obj, idx) { %>" +
+  "<% _.each.convert({ cap: false })(function (obj, idx) { %>" +
   "        * <%= idx %>: <%= obj.source %><% if (obj.refs.length) { %>",
   "            * Files",
   "<% _.each(function (ref) { %>" +
@@ -98,7 +97,7 @@ Files.prototype.textTemplate = _.template([
 
 Files.prototype.tsvTemplate = _.template([
   "File\tIndexes\n",
-  "<% _.each(function (meta, fileName) { %>",
+  "<% _.each.convert({ cap: false })(function (meta, fileName) { %>",
   "<%= fileName %>\t",
   "<%= _.keys((meta || meta.meta).summary).join(\", \") %>\n",
   "<% })(data); %>",
@@ -112,12 +111,12 @@ Files.prototype.getData = function (callback) {
   // Inflate to regex objects of `{ [key], re }`
   var patterns = [].concat(
     // Suspect patterns
-    objMap(opts.suspectFiles ? SUSPECT_FILES : {}, function (pat, key) {
+    _.map.convert({ cap: false })(function (pat, key) {
       return {
         key: key,
         re: new RegExp(pat)
       };
-    }),
+    })(opts.suspectFiles ? SUSPECT_FILES : {}),
 
     // Patterns from user
     _.map(function (pat) {
@@ -140,7 +139,7 @@ Files.prototype.getData = function (callback) {
       // Add matches, filter, and mutate summary.
       var matches = _.flow(
         // Map to match objects: `{ [key], re, match }`
-        _.map(function (obj) {
+        _.map(function (obj) { // eslint-disable-line lodash-fp/no-extraneous-function-wrapping
           return _.extend({
             match: baseName.match(obj.re)
           }, obj);

--- a/lib/actions/parse.js
+++ b/lib/actions/parse.js
@@ -2,7 +2,6 @@
 
 var util = require("util");
 var _ = require("lodash/fp");
-var objMap = require("lodash/map"); // TODO GLOBAL: Unwind this with global config.
 var parse = require("babylon").parse;
 var traverse = require("babel-traverse").default;
 var t = require("babel-types");
@@ -164,9 +163,8 @@ var getReExportedReferencesReport = function (src, reExportedReferences) {
     _.values,
     _.uniqBy(_.identity),
     _.map(function (loc) { // eslint-disable-next-line no-magic-numbers
-      return srcLines.slice(loc.start.line - 1, loc.end.line);
-    }),
-    _.map(function (lines) { return lines.join("\n"); })
+      return srcLines.slice(loc.start.line - 1, loc.end.line).join("\n");
+    })
   )(reExportedReferences);
 
   return snippets.join("\n" + snipped + "\n");
@@ -234,17 +232,17 @@ Parse.prototype.textTemplate = _.template([
   "        * <%= key %>" +
   "<% })(meta.suspectParses); %><% } %>",
   "",
-  "## Files                  <% _.each(function (meta, fileName) { %>",
+  "## Files                  <% _.each.convert({ cap: false })(function (meta, fileName) { %>",
   "* <%= fileName %>" +
   "<% })(data); %>",
   "",
   "## Matches",
-  "<% _.each(function (meta, fileName) { %>",
+  "<% _.each.convert({ cap: false })(function (meta, fileName) { %>",
   "* <%= fileName %>",
   "    * Num Matches:         <%= meta.parse.numMatches %>",
   "    * Num Files Matched:   <%= meta.parse.numFilesMatched %>",
   "",
-  "<% _.each(function (obj, idx) { %>" +
+  "<% _.each.convert({ cap: false })(function (obj, idx) { %>" +
   "    * <%= idx %>: <%= obj.source %><% if (obj.refs.length) { %>",
   "        * Files",
   "<% _.each(function (ref) { %>" +
@@ -262,7 +260,7 @@ Parse.prototype.textTemplate = _.template([
 
 Parse.prototype.tsvTemplate = _.template([
   "File\tIndexes\n",
-  "<% _.each(function (meta, fileName) { %>",
+  "<% _.each.convert({ cap: false })(function (meta, fileName) { %>",
   "<%= fileName %>\t",
   "<%= _.keys((meta || meta.meta).summary).join(\", \") %>\n",
   "<% })(data); %>",
@@ -277,12 +275,12 @@ Parse.prototype.getData = function (callback) {
   // Inflate to objects of `{ [key], fn }`
   var parses = [].concat(
     // Suspect parses
-    objMap(opts.suspectParses ? SUSPECT_PARSES : {}, function (fn, key) {
+    _.map.convert({ cap: false })(function (fn, key) {
       return {
         key: key,
         fn: fn
       };
-    }),
+    }, opts.suspectParses ? SUSPECT_PARSES : {}),
 
     // Parse files from user
     _.map(function (fnPath) {
@@ -303,6 +301,7 @@ Parse.prototype.getData = function (callback) {
       var numMatches = 0;
 
       // Add matches, filter, and mutate summary.
+      // eslint-disable-next-line lodash-fp/no-unused-result
       _.flow(
         // Map to match objects: `{ [key], fn, index, match }`
         _.flatMap(function (obj) {

--- a/lib/actions/pattern.js
+++ b/lib/actions/pattern.js
@@ -2,7 +2,6 @@
 
 var util = require("util");
 var _ = require("lodash/fp");
-var objMap = require("lodash/map");
 
 var Base = require("./base");
 var metaSum = require("../utils/data").metaSum;
@@ -63,21 +62,21 @@ Pattern.prototype.textTemplate = _.template([
   "    * Custom Patterns:     <% _.each(function (pattern) { %>",
   "        * <%= pattern %>" +
   "<% })(opts.pattern); %><% if (opts.suspectPatterns) { %>",
-  "    * Suspect Patterns:    <% _.each(function (pattern, key) { %>",
+  "    * Suspect Patterns:    <% _.each.convert({ cap: false })(function (pattern, key) { %>",
   "        * <%= key %>: <%= pattern %>" +
   "<% })(meta.suspectPatterns); %><% } %>",
   "",
-  "## Files                  <% _.each(function (meta, fileName) { %>",
+  "## Files                  <% _.each.convert({ cap: false })(function (meta, fileName) { %>",
   "* <%= fileName %>" +
   "<% })(data); %>",
   "",
   "## Matches",
-  "<% _.each(function (meta, fileName) { %>",
+  "<% _.each.convert({ cap: false })(function (meta, fileName) { %>",
   "* <%= fileName %>",
   "    * Num Matches:         <%= meta.pattern.numMatches %>",
   "    * Num Files Matched:   <%= meta.pattern.numFilesMatched %>",
   "",
-  "<% _.each(function (obj, idx) { %>" +
+  "<% _.each.convert({ cap: false })(function (obj, idx) { %>" +
   "    * <%= idx %>: <%= obj.source %><% if (obj.refs.length) { %>",
   "        * Files",
   "<% _.each(function (ref) { %>" +
@@ -95,7 +94,7 @@ Pattern.prototype.textTemplate = _.template([
 
 Pattern.prototype.tsvTemplate = _.template([
   "File\tIndexes\n",
-  "<% _.each(function (meta, fileName) { %>",
+  "<% _.each.convert({ cap: false })(function (meta, fileName) { %>",
   "<%= fileName %>\t",
   "<%= _.keys((meta || meta.meta).summary).join(\", \") %>\n",
   "<% })(data); %>",
@@ -110,12 +109,12 @@ Pattern.prototype.getData = function (callback) {
   // Inflate to regex objects of `{ [key], re }`
   var patterns = [].concat(
     // Suspect patterns
-    objMap(opts.suspectPatterns ? SUSPECT_PATTERNS : {}, function (pat, key) {
+    _.map.convert({ cap: false })(function (pat, key) {
       return {
         key: key,
         re: new RegExp(pat)
       };
-    }),
+    })(opts.suspectPatterns ? SUSPECT_PATTERNS : {}),
 
     // Patterns from user
     _.map(function (pat) {
@@ -135,6 +134,7 @@ Pattern.prototype.getData = function (callback) {
       var numMatches = 0;
 
       // Add matches, filter, and mutate summary.
+      // eslint-disable-next-line lodash-fp/no-unused-result
       _.flow(
         // Map to match objects: `{ [key], re, index, match }`
         _.flatMap(function (obj) {

--- a/lib/actions/sizes.js
+++ b/lib/actions/sizes.js
@@ -70,44 +70,42 @@ Sizes.prototype.getData = function (callback) {
   var codes = bundle.codes;
 
   // Convert codes array to sizes array
-  var sizes = _.flow(
-    _.map(function (obj) {
-      // Get code size for any type of chunk.
-      // Reinflate ref (`123`) or refs (`[123, 345]`) for size analysis.
-      var code = obj.code;
-      if (!obj.isCode) {
-        var ref = _.isNumber(obj.ref) ? obj.ref : obj.refs;
-        code = JSON.stringify(ref);
+  var sizes = _.map(function (obj) {
+    // Get code size for any type of chunk.
+    // Reinflate ref (`123`) or refs (`[123, 345]`) for size analysis.
+    var code = obj.code;
+    if (!obj.isCode) {
+      var ref = _.isNumber(obj.ref) ? obj.ref : obj.refs;
+      code = JSON.stringify(ref);
+    }
+
+    // Min+gz sizes.
+    var minSize = "--";
+    var minGzSize = "--";
+    if (obj.isCode && minified) {
+      var codeSrc = toParseable(code);
+      var minSrc = uglify.minify(codeSrc, { fromString: true }).code;
+      minSize = minSrc.length;
+
+      if (gzip) {
+        minGzSize = zlib.gzipSync(minSrc, GZIP_OPTS).length;
       }
+    }
 
-      // Min+gz sizes.
-      var minSize = "--";
-      var minGzSize = "--";
-      if (obj.isCode && minified) {
-        var codeSrc = toParseable(code);
-        var minSrc = uglify.minify(codeSrc, { fromString: true }).code;
-        minSize = minSrc.length;
-
-        if (gzip) {
-          minGzSize = zlib.gzipSync(minSrc, GZIP_OPTS).length;
-        }
+    return {
+      index: obj.index,
+      baseName: obj.baseName,
+      fileName: obj.fileName,
+      type: obj.isTemplate ? "template" : // eslint-disable-line no-nested-ternary
+        obj.isCode ? "code" :
+        "reference",
+      size: {
+        full: code.length,
+        min: obj.isCode ? minSize : code.length,
+        minGz: obj.isCode ? minGzSize : code.length
       }
-
-      return {
-        index: obj.index,
-        baseName: obj.baseName,
-        fileName: obj.fileName,
-        type: obj.isTemplate ? "template" : // eslint-disable-line no-nested-ternary
-          obj.isCode ? "code" :
-          "reference",
-        size: {
-          full: code.length,
-          min: obj.isCode ? minSize : code.length,
-          minGz: obj.isCode ? minGzSize : code.length
-        }
-      };
-    })
-  )(codes);
+    };
+  })(codes);
 
   var bundleMinSrc = minified ? uglify.minify(bundle.code, { fromString: true }).code : null;
 

--- a/lib/actions/versions.js
+++ b/lib/actions/versions.js
@@ -72,7 +72,7 @@ var addRequirePathToPackageMap = function (pkg, requirePath, pkgMap) {
   // Ensure array, add path, and filter to sorted uniques.
   var updates = (pkgMap[pkg.name][pkg.version] || []).concat([requirePath]);
   pkgMap[pkg.name][pkg.version] = _.flow(
-    _.uniq(),
+    _.uniq,
     _.sortBy(_.identity)
   )(updates);
 
@@ -135,7 +135,8 @@ var getSkewedDepsWithGraphInfo = function (rootDirStructure, allPackagesInBundle
     requiredByString += requiredByString ? " -> " + packageString : "root";
 
     if (packageJSON.dependencies) {
-      _.each(createCheckDepFunction(requiredByString, modulePath))(packageJSON.dependencies);
+      var checkFn = createCheckDepFunction(requiredByString, modulePath);
+      _.each.convert({ cap: false })(checkFn)(packageJSON.dependencies);
     }
   };
 
@@ -144,9 +145,8 @@ var getSkewedDepsWithGraphInfo = function (rootDirStructure, allPackagesInBundle
   skewedPackageMap = getSkewedPackageMap(packageMap);
 
   // Add lost puppies back to skewedPackageMap
-  _.each(function (consumerList, depName) {
+  _.each.convert({ cap: false })(function (consumerList, depName) {
     if (skewedPackageMap[depName]) {
-
       skewedPackageMap[depName].unknownResolvedVersion = consumerList;
     }
   })(notFoundPackages);
@@ -219,7 +219,7 @@ Versions.prototype.textTemplate = _.template([
   "<% })(obj.skewedDeps); %>",
   "",
   "  * Versions: <%= Object.keys(obj.versions).length %>" +
-  "<% _.each(function (versionsGroup, key) { %>",
+  "<% _.each.convert({ cap: false })(function (versionsGroup, key) { %>",
   "    * <%= key %>: <% _.each(function (versionItem) { %>",
   "      * <%= versionItem %>" +
   "<% })(versionsGroup); %>" +
@@ -239,7 +239,7 @@ Versions.prototype.tsvTemplate = _.template([
 
 /*eslint-disable max-statements*/
 Versions.prototype.getData = function (callback) {
-  var pathRoot = this.opts.root;
+  var pathRoot = path.resolve(this.opts.root);
   var codes = this.bundle.codes;
 
   var allPackagesInBundle = {};
@@ -250,6 +250,8 @@ Versions.prototype.getData = function (callback) {
   var rootPackageJSONPath = path.join(pathRoot, bundleLocationFromRoot, "package.json");
   var rootPackageJSON = getPackageJSON(rootPackageJSONPath);
 
+  // Mutate outside variables.
+  // eslint-disable-next-line lodash-fp/no-unused-result
   _.flow(
     // Remove non node_module code pieces
     _.filter(isCodeANodeModule),

--- a/lib/args.js
+++ b/lib/args.js
@@ -6,13 +6,7 @@ var yargs = require("yargs");
 var TERMINAL_CHARS = 100;
 var NOT_FOUND = -1;
 
-var ACTIONS = [
-  "duplicates",
-  "files",
-  "versions",
-  "pattern",
-  "sizes"
-];
+var ACTIONS = Object.keys(require("./actions").ACTIONS);
 
 /**
  * Validation wrapper

--- a/lib/models/bundle.js
+++ b/lib/models/bundle.js
@@ -352,11 +352,11 @@ Bundle.prototype._groupByType = function () {
         template: _.filter({ isTemplate: true })(codes),
         ref: _.flow(
           _.filter(function (code) { return code.ref !== null; }),
-          _.map(function (code) { return _.omit("code")(code); })
+          _.map(_.omit("code"))
         )(codes),
         refs: _.flow(
           _.filter(function (code) { return code.refs !== null; }),
-          _.map(function (code) { return _.omit("code")(code); })
+          _.map(_.omit("code"))
         )(codes)
       };
     })

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "eslint": "^2.4.0",
     "eslint-config-defaults": "^10.0.0-alpha.1",
-    "eslint-plugin-filenames": "^0.2.0"
+    "eslint-plugin-filenames": "^0.2.0",
+    "eslint-plugin-lodash-fp": "^1.3.0"
   }
 }


### PR DESCRIPTION
So we've been playing fast and loose with use of `lodash/fp`. `_.each()` previously passed a second parameter that it no longer does in "within semver" update breaking things.

This PR:

* Explicitly uses `.convert({ cap: false })` for uses of `_.each()` and `_.map` that need the second argument.
* Removes one-off imports of non-fp `lodash` for getting around this. Fixes #12
* Adds `lodash/fp` lint and cleans up everything.

/cc @markbrouch @divmain @rgerstenberger 