### PR TITLE
Fix module header scraping for Webpack 2

### DIFF
--- a/lib/models/bundle.js
+++ b/lib/models/bundle.js
@@ -26,6 +26,19 @@ var Code = function Code(opts) {
 };
 
 /**
+ * Return only the Webpack comment header of a raw code string.
+ *
+ * @param   {String} code Raw JavaScript code
+ * @returns {String}      The Webpack comment header.
+ */
+Code.prototype._getWebpackHeader = function (code) {
+  var endToken = "/***/ ";
+  var endIndex = code.indexOf(endToken);
+  // eslint-disable-next-line no-magic-numbers
+  return code.substring(0, endIndex + endToken.length);
+};
+
+/**
  * Return file name of line.
  *
  * @param   {String} code Raw JavaScript code
@@ -40,10 +53,13 @@ Code.prototype._getFileName = function (code) {
   // 2   !*** ../foo/awesomez.js ***!       <-- Filename on line 2.
   // 3   \**************************/
   // ```
-  return (code.split("\n", 3)[2] || "") // eslint-disable-line no-magic-numbers
-    .replace("!***", "")
-    .replace("***!", "")
-    .replace(/^\s*|\s*$/g, "");
+  var webpackHeader = this._getWebpackHeader(code);
+  var beginningToken = "!*** ";
+  var endToken = " ***!";
+
+  var beginningIndex = webpackHeader.indexOf(beginningToken);
+  var endIndex = webpackHeader.indexOf(endToken);
+  return code.substring(beginningIndex + beginningToken.length, endIndex);
 };
 
 /**
@@ -103,7 +119,12 @@ Code.prototype._isCode = function (code) {
   // [2612, 505, 506, 508, 509],                               <-- Not code! L4
   // ```
   /*eslint-disable no-magic-numbers*/
-  return (code.split("\n", 5)[4] || "").indexOf("/***/ function") === 0;
+  var webpackHeader = this._getWebpackHeader(code);
+  var rawCode = code.substring(webpackHeader.length);
+
+  // For some reason, different Webpack versions emit either a plain function or an IIFE
+  return rawCode.indexOf("function") === 0 ||
+    rawCode.indexOf("(function") === 0;
 };
 
 /**


### PR DESCRIPTION
Webpack 2 adds extra comments for tracking module uses for tree-shaking, so the hardcoded line numbers resulted in code sections being treated as references. This decouples the header scraping from the line numbers.