### PR TITLE
Accept raw bundle strings in action options

### DIFF
--- a/lib/actions/duplicates.js
+++ b/lib/actions/duplicates.js
@@ -202,6 +202,7 @@ Duplicates.prototype.getData = function (callback) {
  *
  * @param {Object}    opts          Options
  * @param {String}    opts.bundle   Bundle file path
+ * @param {String}    opts.code     Raw bundle string
  * @param {String}    opts.format   Output format type
  * @param {Boolean}   opts.verbose  Verbose output?
  * @param {Boolean}   opts.minified Minified calculations / output?

--- a/lib/actions/files.js
+++ b/lib/actions/files.js
@@ -192,6 +192,7 @@ Files.prototype.getData = function (callback) {
  *
  * @param {Object}    opts              Options
  * @param {String}    opts.bundle       Bundle file path
+ * @param {String}    opts.code         Raw bundle string
  * @param {Array}     opts.pattern      1+ patterns
  * @param {Boolean}   opts.suspectFiles Use suspect files enum
  * @param {String}    opts.format       Output format type

--- a/lib/actions/parse.js
+++ b/lib/actions/parse.js
@@ -367,6 +367,7 @@ Parse.prototype.getData = function (callback) {
  *
  * @param {Object}    opts                  Options
  * @param {String}    opts.bundle           Bundle file path
+ * @param {String}    opts.code             Raw bundle string
  * @param {Array}     opts.parse            1+ file paths to parse functions
  * @param {Boolean}   opts.suspectParses    Use suspect parses enum
  * @param {String}    opts.format           Output format type

--- a/lib/actions/pattern.js
+++ b/lib/actions/pattern.js
@@ -201,6 +201,7 @@ Pattern.prototype.getData = function (callback) {
  *
  * @param {Object}    opts                  Options
  * @param {String}    opts.bundle           Bundle file path
+ * @param {String}    opts.code             Raw bundle string
  * @param {Array}     opts.pattern          1+ patterns
  * @param {Boolean}   opts.suspectPatterns  Use suspect files enum
  * @param {String}    opts.format           Output format type

--- a/lib/actions/sizes.js
+++ b/lib/actions/sizes.js
@@ -127,6 +127,7 @@ Sizes.prototype.getData = function (callback) {
  *
  * @param {Object}    opts          Options
  * @param {String}    opts.bundle   Bundle file path
+ * @param {String}    opts.code     Raw bundle string
  * @param {String}    opts.format   Output format type
  * @param {Boolean}   opts.verbose  Verbose output?
  * @param {Boolean}   opts.minified Minified calculations / output?

--- a/lib/actions/versions.js
+++ b/lib/actions/versions.js
@@ -377,6 +377,7 @@ Versions.prototype.getData = function (callback) {
  *
  * @param {Object}    opts                  Options
  * @param {String}    opts.bundle           Bundle file path
+ * @param {String}    opts.code             Raw bundle string
  * @param {Array}     opts.root             Root path to project
  * @param {String}    opts.format           Output format type
  * @param {Boolean}   opts.duplicates       Filter to missed deduplication opportunities.

--- a/lib/models/bundle.js
+++ b/lib/models/bundle.js
@@ -504,16 +504,34 @@ Bundle.prototype._validateGroups = function () {
  *
  * @param {Object}    opts        Options
  * @param {String}    opts.bundle Path to bundle file
+ * @param {String}    opts.code   A raw string of a bundle
  * @param {Function}  callback    Form `(err, data)`
  * @returns {void}
  */
 Bundle.create = function (opts, callback) {
   // Validate. (Would be programming error).
-  if (!opts.bundle) {
-    throw new Error("Bundle option required");
+  if (!opts.bundle && !opts.code) {
+    throw new Error("Bundle or code option required");
   }
 
-  fs.readFile(opts.bundle, function (err, data) {
+  if (opts.bundle && opts.code) {
+    throw new Error("Bundle and code options are mutually exclusive");
+  }
+
+  if (opts.code) {
+    // Prevent Zalgo by executing on the next tick.
+    return setImmediate(function () {
+      var bundle = new Bundle({
+        code: opts.code
+      });
+
+      bundle.validate();
+
+      callback(null, bundle);
+    });
+  }
+
+  return fs.readFile(opts.bundle, function (err, data) {
     if (err) {
       callback(err);
       return;


### PR DESCRIPTION
This is useful for processing in-memory Webpack bundles (say, for getting _real_ module sizes in `webpack-dashboard` 😃 