### PR TITLE
Daemon mode with performance improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 100
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,11 @@
 ---
 extends:
   - "plugin:lodash-fp/recommended"
-  - "defaults/configurations/walmart/es5-node"
+  - formidable/configurations/es6-node
 
 plugins:
   - lodash-fp
 
 rules:
-  strict: 0
-  no-magic-numbers: ["error", { "ignore": [-1, 0, 1] }]
+  func-style: off
+  arrow-parens: off

--- a/bin/inspectpack.js
+++ b/bin/inspectpack.js
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
 "use strict";
 
-var args = require("../lib").args;
-var actions = require("../lib").actions;
+const args = require("../lib").args;
+const actions = require("../lib").actions;
 
 // The main event.
-var main = function () {
+const main = function () {
   // Parse arguments.
-  var parser = args.parse();
-  var argv = args.validate(parser);
+  const parser = args.parse();
+  const argv = args.validate(parser);
 
   // Invoke action.
-  actions(argv.action)(argv, function (err, data) {
+  actions(argv.action)(argv, (err, data) => {
     if (err) {
       // Try to get full stack, then full string if not.
       console.error(err.stack || err.toString()); // eslint-disable-line no-console

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -21,7 +21,7 @@ module.exports = function (name) {
   const action = ACTIONS[name];
   if (!action) {
     // This is a programming error. Arg parsing _should_ have caught already.
-    throw new Error(`Unknown action: ${ name}`);
+    throw new Error(`Unknown action: ${name}`);
   }
 
   return action;

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var ACTIONS = {
+const ACTIONS = {
   /*eslint-disable global-require*/
   duplicates: require("./actions/duplicates"),
   pattern: require("./actions/pattern"),
@@ -18,10 +18,10 @@ var ACTIONS = {
  * @returns {Function}        Action function
  */
 module.exports = function (name) {
-  var action = ACTIONS[name];
+  const action = ACTIONS[name];
   if (!action) {
     // This is a programming error. Arg parsing _should_ have caught already.
-    throw new Error("Unknown action: " + name);
+    throw new Error(`Unknown action: ${ name}`);
   }
 
   return action;

--- a/lib/actions/base.js
+++ b/lib/actions/base.js
@@ -1,10 +1,10 @@
 "use strict";
 
-var _ = require("lodash/fp");
+const _ = require("lodash/fp");
 
-var Bundle = require("../models/bundle");
+const Bundle = require("../models/bundle");
 
-var JSON_SPACES = 2;
+const JSON_SPACES = 2;
 
 /**
  * Base abstraction for actions.
@@ -14,7 +14,7 @@ var JSON_SPACES = 2;
  * @param {Object} opts.bundle  Bundle object
  * @returns {void}
  */
-var Base = module.exports = function Base(opts) {
+const Base = module.exports = function Base(opts) {
   this.opts = opts.opts;
   this.bundle = opts.bundle;
 };
@@ -36,8 +36,8 @@ Base.prototype.getData = function (/*callback*/) {
  * @returns {String}        Formatted string
  */
 Base.prototype.display = function (data) {
-  var opts = this.opts;
-  var format = opts.format;
+  const opts = this.opts;
+  const format = opts.format;
 
   switch (format) {
   case "object":
@@ -46,7 +46,7 @@ Base.prototype.display = function (data) {
     return JSON.stringify(data, null, JSON_SPACES);
   case "text":
     return this.textTemplate({
-      opts: opts,
+      opts,
       data: _.omit("meta")(data),
       meta: data.meta
     });
@@ -56,13 +56,13 @@ Base.prototype.display = function (data) {
     }
 
     return this.tsvTemplate({
-      opts: opts,
+      opts,
       data: _.omit("meta")(data),
       meta: data.meta
     });
   default:
     // Programming error.
-    throw new Error("Unknown format: " + format);
+    throw new Error(`Unknown format: ${ format}`);
   }
 };
 
@@ -76,27 +76,27 @@ Base.prototype.display = function (data) {
  * @returns {void}
  */
 Base.createWithBundle = function (opts, callback) {
-  var Cls = this; // eslint-disable-line consistent-this
+  const Cls = this; // eslint-disable-line consistent-this
   if (!Cls instanceof Base) {
     throw new Error("Must bind an actions/base instance");
   }
 
-  Bundle.create(opts, function (bundleErr, bundle) {
+  Bundle.create(opts, (bundleErr, bundle) => {
     if (bundleErr) {
       callback(bundleErr);
       return;
     }
 
     // Create action instance and get data for report.
-    var instance = new Cls({
-      opts: opts,
-      bundle: bundle
+    const instance = new Cls({
+      opts,
+      bundle
     });
 
     try {
-      instance.getData(function (err, data) {
+      instance.getData((err, data) => {
         // Format data and return.
-        var output = !err ? instance.display(data) : null;
+        const output = !err ? instance.display(data) : null;
         callback(err, output);
       });
     } catch (err) {

--- a/lib/actions/base.js
+++ b/lib/actions/base.js
@@ -62,7 +62,7 @@ Base.prototype.display = function (data) {
     });
   default:
     // Programming error.
-    throw new Error(`Unknown format: ${ format}`);
+    throw new Error(`Unknown format: ${format}`);
   }
 };
 

--- a/lib/actions/duplicates.js
+++ b/lib/actions/duplicates.js
@@ -1,16 +1,16 @@
 "use strict";
 
-var zlib = require("zlib");
-var util = require("util");
+const zlib = require("zlib");
+const util = require("util");
 
-var _ = require("lodash/fp");
-var uglify = require("uglify-js");
+const _ = require("lodash/fp");
+const uglify = require("uglify-js");
 
-var Base = require("./base");
-var metaSum = require("../utils/data").metaSum;
-var toParseable = require("../utils/code").toParseable;
+const Base = require("./base");
+const metaSum = require("../utils/data").metaSum;
+const toParseable = require("../utils/code").toParseable;
 
-var GZIP_OPTS = { level: 9 };
+const GZIP_OPTS = { level: 9 };
 
 /**
  * Add full, minified, gzipped size data points.
@@ -21,26 +21,26 @@ var GZIP_OPTS = { level: 9 };
  * @param {Boolean}   opts.gzip     Minified + gzipped calculations / output?
  * @return {Function}               Mutates object values
  */
-var addSizes = function (codes, opts) {
-  var minified = opts.minified || opts.gzip;
-  var gzip = opts.gzip;
+const addSizes = function (codes, opts) {
+  const minified = opts.minified || opts.gzip;
+  const gzip = opts.gzip;
 
-  return _.mapValues(function (group) {
-    var meta = group.meta;
+  return _.mapValues((group) => {
+    const meta = group.meta;
 
     // Track total sizes.
-    var totalFullSize = 0;
-    var totalMinSize = 0;
-    var totalMinGzSize = 0;
-    var minMinSize = null;
-    var minMinGzSize = null;
+    let totalFullSize = 0;
+    let totalMinSize = 0;
+    let totalMinGzSize = 0;
+    let minMinSize = null;
+    let minMinGzSize = null;
 
     // Update summary items.
-    _.each.convert({ cap: false })(function (obj, idx) {
+    _.each.convert({ cap: false })((obj, idx) => {
       // Mutate sizes.
-      var codeSrc = toParseable(_.find({ id: parseInt(idx, 10) })(codes).code);
-      var fullSize = codeSrc.length;
-      var minSrc = minified ? uglify.minify(codeSrc, {
+      const codeSrc = toParseable(_.find({ id: parseInt(idx, 10) })(codes).code);
+      const fullSize = codeSrc.length;
+      const minSrc = minified ? uglify.minify(codeSrc, {
         fromString: true,
         warnings: false,
         output: {
@@ -48,8 +48,8 @@ var addSizes = function (codes, opts) {
           max_line_len: Infinity
         }
       }).code : null;
-      var minSize = minified ? minSrc.length : "--";
-      var minGzSize = gzip ? zlib.gzipSync(minSrc, GZIP_OPTS).length : "--";
+      const minSize = minified ? minSrc.length : "--";
+      const minGzSize = gzip ? zlib.gzipSync(minSrc, GZIP_OPTS).length : "--";
 
       // Update stateful aggregators.
       totalFullSize += fullSize;
@@ -90,7 +90,7 @@ var addSizes = function (codes, opts) {
  *
  * @returns {void}
  */
-var Duplicates = function Duplicates() {
+const Duplicates = function Duplicates() {
   Base.apply(this, arguments);
 };
 
@@ -152,29 +152,29 @@ Duplicates.prototype.tsvTemplate = _.template([
 
 Duplicates.prototype.getData = function (callback) {
   // Options.
-  var opts = this.opts;
-  var minified = opts.minified || opts.gzip;
-  var gzip = opts.gzip;
+  const opts = this.opts;
+  const minified = opts.minified || opts.gzip;
+  const gzip = opts.gzip;
 
   // Bundle.
-  var bundle = this.bundle;
-  var codes = bundle.codes;
+  const bundle = this.bundle;
+  const codes = bundle.codes;
 
   // Create data object.
-  var data = _.flow(
+  const data = _.flow(
     // Filter to actual missed duplicates.
-    _.pickBy(function (g) {
+    _.pickBy((g) => {
       return g.meta.uniqIdxs.length > 1; // eslint-disable-line no-magic-numbers
     }),
     addSizes(codes, opts),
     // Filter to just `meta` unless verbose.
-    _.mapValues(function (g) { return opts.verbose ? g : g.meta; })
+    _.mapValues((g) => { return opts.verbose ? g : g.meta; })
   )(bundle.groups);
 
   // Add entire bundle metadata.
-  var numFilesWithDuplicates = _.keys(data).length;
-  var numAllFiles = metaSum("uniqIdxs.length")(data);
-  var minSrc = minified ? uglify.minify(bundle.code, {
+  const numFilesWithDuplicates = _.keys(data).length;
+  const numAllFiles = metaSum("uniqIdxs.length")(data);
+  const minSrc = minified ? uglify.minify(bundle.code, {
     fromString: true,
     warnings: false,
     output: {
@@ -185,7 +185,7 @@ Duplicates.prototype.getData = function (callback) {
 
   data.meta = {
     // Unique baseNames that have misses.
-    numFilesWithDuplicates: numFilesWithDuplicates,
+    numFilesWithDuplicates,
     // The number of extra files that we could reduce.
     numFilesExtra: numAllFiles - numFilesWithDuplicates,
 

--- a/lib/actions/files.js
+++ b/lib/actions/files.js
@@ -1,21 +1,21 @@
 "use strict";
 
-var util = require("util");
-var _ = require("lodash/fp");
+const util = require("util");
+const _ = require("lodash/fp");
 
-var Base = require("./base");
-var metaSum = require("../utils/data").metaSum;
+const Base = require("./base");
+const metaSum = require("../utils/data").metaSum;
 
-var FULL_MATCH_GROUP = 0; // Full matched group is at index 0.
-var PAIR_KEY = 0; // for `.toPairs|.fromPairs`
-var PAIR_VAL = 1; // for `.toPairs|.fromPairs`
+const FULL_MATCH_GROUP = 0; // Full matched group is at index 0.
+const PAIR_KEY = 0; // for `.toPairs|.fromPairs`
+const PAIR_VAL = 1; // for `.toPairs|.fromPairs`
 
 /**
  * Suspect patterns.
  *
  * For `--suspect-files`.
  */
-var SUSPECT_FILES = {
+const SUSPECT_FILES = {
   // Lodash libs with known multiple exports / overinclusive bundles
   //
   // **Note**: Based off `lodash@4.6.1`
@@ -47,7 +47,7 @@ var SUSPECT_FILES = {
  *
  * @returns {void}
  */
-var Files = function Files() {
+const Files = function Files() {
   Base.apply(this, arguments);
 };
 
@@ -105,21 +105,21 @@ Files.prototype.tsvTemplate = _.template([
 ].join(""));
 
 Files.prototype.getData = function (callback) {
-  var opts = this.opts;
-  var bundle = this.bundle;
+  const opts = this.opts;
+  const bundle = this.bundle;
 
   // Inflate to regex objects of `{ [key], re }`
-  var patterns = [].concat(
+  const patterns = [].concat(
     // Suspect patterns
-    _.map.convert({ cap: false })(function (pat, key) {
+    _.map.convert({ cap: false })((pat, key) => {
       return {
-        key: key,
+        key,
         re: new RegExp(pat)
       };
     })(opts.suspectFiles ? SUSPECT_FILES : {}),
 
     // Patterns from user
-    _.map(function (pat) {
+    _.map((pat) => {
       return {
         re: new RegExp(pat)
       };
@@ -127,29 +127,29 @@ Files.prototype.getData = function (callback) {
   );
 
   // Create data object.
-  var data = _.flow(
+  const data = _.flow(
     // Pairs since lodash/fp doesn't pass key to map|mapValues :(
     _.toPairs,
 
     // Mutate summary with pattern matches.
-    _.map(function (pair) {
-      var baseName = pair[PAIR_KEY];
-      var meta = pair[PAIR_VAL].meta;
+    _.map((pair) => {
+      const baseName = pair[PAIR_KEY];
+      const meta = pair[PAIR_VAL].meta;
 
       // Add matches, filter, and mutate summary.
-      var matches = _.flow(
+      const matches = _.flow(
         // Map to match objects: `{ [key], re, match }`
-        _.map(function (obj) { // eslint-disable-line lodash-fp/no-extraneous-function-wrapping
+        _.map((obj) => { // eslint-disable-line lodash-fp/no-extraneous-function-wrapping
           return _.extend({
             match: baseName.match(obj.re)
           }, obj);
         }),
 
         // Only keep matches.
-        _.filter(function (obj) { return obj.match; }),
+        _.filter((obj) => { return obj.match; }),
 
         // Map to final form and mutate summary: `{ [key], pattern, match }`
-        _.map(function (obj) {
+        _.map((obj) => {
           return {
             key: obj.key,
             pattern: obj.re.toString(),
@@ -161,7 +161,7 @@ Files.prototype.getData = function (callback) {
       // Add files data.
       meta.files = {
         numMatches: matches.length,
-        matches: matches
+        matches
       };
 
       return pair;
@@ -171,10 +171,10 @@ Files.prototype.getData = function (callback) {
     _.fromPairs,
 
     // Filter to 1+ matches.
-    _.pickBy(function (g) { return !!g.meta.files.numMatches; }),
+    _.pickBy((g) => { return !!g.meta.files.numMatches; }),
 
     // Filter to just `meta` unless verbose.
-    _.mapValues(function (g) { return opts.verbose ? g : g.meta; })
+    _.mapValues((g) => { return opts.verbose ? g : g.meta; })
   )(bundle.groups);
 
   // Metadata

--- a/lib/actions/parse.js
+++ b/lib/actions/parse.js
@@ -1,21 +1,21 @@
 "use strict";
 
-var util = require("util");
-var _ = require("lodash/fp");
-var parse = require("babylon").parse;
-var traverse = require("babel-traverse").default;
-var t = require("babel-types");
+const util = require("util");
+const _ = require("lodash/fp");
+const parse = require("babylon").parse;
+const traverse = require("babel-traverse").default;
+const t = require("babel-types");
 
-var Base = require("./base");
-var metaSum = require("../utils/data").metaSum;
-var toParseable = require("../utils/code").toParseable;
+const Base = require("./base");
+const metaSum = require("../utils/data").metaSum;
+const toParseable = require("../utils/code").toParseable;
 
 // Parse helpers
-var isExports = function (node) {
+const isExports = function (node) {
   return t.isIdentifier(node) && node.name === "exports";
 };
 
-var isModuleExports = function (node) {
+const isModuleExports = function (node) {
   return t.isMemberExpression(node) &&
     t.isIdentifier(node.object) &&
     t.isIdentifier(node.property) &&
@@ -23,7 +23,7 @@ var isModuleExports = function (node) {
     node.property.name === "exports";
 };
 
-var isExportsSubproperty = function (node) {
+const isExportsSubproperty = function (node) {
   if (!node.object) { return false; }
 
   return isExports(node.object) ||
@@ -32,29 +32,29 @@ var isExportsSubproperty = function (node) {
     isExportsSubproperty(node.object);
 };
 
-var isWebpackRequire = function (node) {
+const isWebpackRequire = function (node) {
   return t.isCallExpression(node) &&
     t.isIdentifier(node.callee) &&
     node.callee.name === "__webpack_require__";
 };
 
-var isInteropCall = function (node) {
+const isInteropCall = function (node) {
   return t.isCallExpression(node) &&
     t.isIdentifier(node.callee) &&
     node.callee.name === "_interopRequireDefault";
 };
 
-var isAssignmentExpressionStmt = function (node) {
+const isAssignmentExpressionStmt = function (node) {
   return t.isExpressionStatement(node) && t.isAssignmentExpression(node.expression);
 };
 
-var isEs6ModuleFlag = function (node) {
+const isEs6ModuleFlag = function (node) {
   if (!isAssignmentExpressionStmt(node)) {
     return false;
   }
 
-  var left = node.expression.left;
-  var right = node.expression.right;
+  const left = node.expression.left;
+  const right = node.expression.right;
 
   return node.expression.operator === "=" &&
     t.isMemberExpression(left) &&
@@ -66,13 +66,13 @@ var isEs6ModuleFlag = function (node) {
     right.value === true;
 };
 
-var getReExportedReferences = function (moduleAst) {
-  var otherModuleReferences = {};
+const getReExportedReferences = function (moduleAst) {
+  const otherModuleReferences = {};
 
   traverse(moduleAst, {
     noScope: true,
-    AssignmentExpression: function (path) {
-      var node = path.node;
+    AssignmentExpression(path) {
+      const node = path.node;
 
       if (
         // module.exports.foo.something = __webpack_require__(4);
@@ -87,7 +87,7 @@ var getReExportedReferences = function (moduleAst) {
         t.isObjectExpression(node.right) &&
         isModuleExports(node.left)
       ) {
-        _.each(function (objectProperty) {
+        _.each((objectProperty) => {
           if (isWebpackRequire(objectProperty.value)) {
             // eslint-disable-next-line no-magic-numbers
             otherModuleReferences[objectProperty.value.arguments[0].value] = node.right.loc;
@@ -100,19 +100,21 @@ var getReExportedReferences = function (moduleAst) {
   return otherModuleReferences;
 };
 
-var getReExportedEs6References = function (moduleAst) {
-  var moduleBody = _.get("program.body[0].expression.right.body.body")(moduleAst);
-  var identifierToWebpackModule = {};
-  var otherModuleReferences = {};
+const getReExportedEs6References = function (moduleAst) {
+  const moduleBody = _.get("program.body[0].expression.right.body.body")(moduleAst);
+  const identifierToWebpackModule = {};
+  const otherModuleReferences = {};
 
-  var isEs6Module = false;
-  moduleBody.forEach(function (node) {
+  let isEs6Module = false;
+  let webpackModule;
+
+  moduleBody.forEach((node) => {
     if (isEs6Module) {
       if (
         t.isVariableDeclaration(node) &&
         node.declarations.length === 1 // eslint-disable-line no-magic-numbers
       ) {
-        var decl = node.declarations[0]; // eslint-disable-line no-magic-numbers
+        const decl = node.declarations[0]; // eslint-disable-line no-magic-numbers
 
         if (isWebpackRequire(decl.init)) {
           // var _thing = __webpack_require__(244);
@@ -121,8 +123,8 @@ var getReExportedEs6References = function (moduleAst) {
         } else if (isInteropCall(decl.init)) {
           // var _thing2 = _interopRequireDefault(_thing)
           // eslint-disable-next-line no-magic-numbers
-          var unShimedIndentifierName = decl.init.arguments[0] && decl.init.arguments[0].name;
-          var webpackModule = identifierToWebpackModule[unShimedIndentifierName];
+          const unShimedIndentifierName = decl.init.arguments[0] && decl.init.arguments[0].name;
+          webpackModule = identifierToWebpackModule[unShimedIndentifierName];
           if (_.isNumber(webpackModule)) {
             identifierToWebpackModule[decl.id.name] = webpackModule;
           }
@@ -147,8 +149,8 @@ var getReExportedEs6References = function (moduleAst) {
   return otherModuleReferences;
 };
 
-var getReExportedReferencesReport = function (src, reExportedReferences) {
-  var snipped = "// ...";
+const getReExportedReferencesReport = function (src, reExportedReferences) {
+  const snipped = "// ...";
 
   // Check if we have one or less re-export (in which case we don't care.)
   if (_.keys(reExportedReferences).length < 2) { // eslint-disable-line no-magic-numbers
@@ -157,17 +159,17 @@ var getReExportedReferencesReport = function (src, reExportedReferences) {
 
   // Create a truncated version of output text with _just_ the re-export
   // matches
-  var srcLines = src.split("\n");
+  const srcLines = src.split("\n");
 
-  var snippets = _.flow(
+  const snippets = _.flow(
     _.values,
     _.uniqBy(_.identity),
-    _.map(function (loc) { // eslint-disable-next-line no-magic-numbers
+    _.map((loc) => { // eslint-disable-next-line no-magic-numbers
       return srcLines.slice(loc.start.line - 1, loc.end.line).join("\n");
     })
   )(reExportedReferences);
 
-  return snippets.join("\n" + snipped + "\n");
+  return snippets.join(`\n${ snipped }\n`);
 };
 
 /**
@@ -175,7 +177,7 @@ var getReExportedReferencesReport = function (src, reExportedReferences) {
  *
  * For `--suspect-parses`.
  */
-var SUSPECT_PARSES = {
+const SUSPECT_PARSES = {
   // Multiple Exports.
   //
   // ```js
@@ -189,14 +191,14 @@ var SUSPECT_PARSES = {
   // module.exports.foo = __webpack_require__(1);
   // module.exports.bar = __webpack_require__(2);
   // ```
-  MULTIPLE_EXPORTS: function (src) {
-    var ast = parse(src, { sourceType: "module" });
-    var reExportedReferences = getReExportedReferences(ast);
+  MULTIPLE_EXPORTS(src) {
+    const ast = parse(src, { sourceType: "module" });
+    const reExportedReferences = getReExportedReferences(ast);
     return getReExportedReferencesReport(src, reExportedReferences);
   },
-  MULTIPLE_EXPORTS_ES: function (src) {
-    var ast = parse(src, { sourcetype: "module" });
-    var reExportedReferences = getReExportedEs6References(ast);
+  MULTIPLE_EXPORTS_ES(src) {
+    const ast = parse(src, { sourcetype: "module" });
+    const reExportedReferences = getReExportedEs6References(ast);
     return getReExportedReferencesReport(src, reExportedReferences);
   }
 };
@@ -206,7 +208,7 @@ var SUSPECT_PARSES = {
  *
  * @returns {void}
  */
-var Parse = function Parse() {
+const Parse = function Parse() {
   Base.apply(this, arguments);
 };
 
@@ -268,18 +270,18 @@ Parse.prototype.tsvTemplate = _.template([
 ].join(""));
 
 Parse.prototype.getData = function (callback) {
-  var opts = this.opts;
-  var bundle = this.bundle;
-  var codes = bundle.codes;
-  var parseFns = this.opts.parseFns || {};
+  const opts = this.opts;
+  const bundle = this.bundle;
+  const codes = bundle.codes;
+  const parseFns = this.opts.parseFns || {};
 
   // Inflate to objects of `{ [key], fn }`
-  var parses = [].concat(
+  const parses = [].concat(
     // Suspect parses
-    _.map.convert({ cap: false })(function (fn, key) {
+    _.map.convert({ cap: false })((fn, key) => {
       return {
-        key: key,
-        fn: fn
+        key,
+        fn
       };
     }, opts.suspectParses
       ? _.assign(SUSPECT_PARSES)(parseFns)
@@ -287,7 +289,7 @@ Parse.prototype.getData = function (callback) {
     ),
 
     // Parse files from user
-    _.map(function (fnPath) {
+    _.map((fnPath) => {
       return {
         key: fnPath,
         fn: require(fnPath) // eslint-disable-line global-require
@@ -296,21 +298,21 @@ Parse.prototype.getData = function (callback) {
   );
 
   // Create data object.
-  var data = _.flow(
+  const data = _.flow(
     // Mutate summary with parse matches.
-    _.mapValues(function (group) {
-      var meta = group.meta;
+    _.mapValues((group) => {
+      const meta = group.meta;
 
       // Stateful counters.
-      var numMatches = 0;
+      let numMatches = 0;
 
       // Add matches, filter, and mutate summary.
       // eslint-disable-next-line lodash-fp/no-unused-result
       _.flow(
         // Map to match objects: `{ [key], fn, index, match }`
-        _.flatMap(function (obj) {
+        _.flatMap((obj) => {
           // Try to match for all unique indexes in play.
-          return _.flatMap(function (idx) {
+          return _.flatMap((idx) => {
             return _.extend({
               index: idx,
               match: obj.fn(toParseable(_.find({ id: idx })(codes).code))
@@ -319,13 +321,13 @@ Parse.prototype.getData = function (callback) {
         }),
 
         // Only keep matches.
-        _.filter(function (obj) { return obj.match; }),
+        _.filter((obj) => { return obj.match; }),
 
         // Get number of matches.
-        _.tap(function (objs) { numMatches = objs.length; }),
+        _.tap((objs) => { numMatches = objs.length; }),
 
         // Map to final form and mutate summary: `{ [key], parse, match }`
-        _.each(function (obj) {
+        _.each((obj) => {
           meta.summary[obj.index].matches = [].concat(
             meta.summary[obj.index].matches || [],
             [{
@@ -337,11 +339,11 @@ Parse.prototype.getData = function (callback) {
       )(parses);
 
       // Mutate summary to remove _unmatched_ indexes.
-      meta.summary = _.pickBy(function (val) { return !!val.matches; })(meta.summary);
+      meta.summary = _.pickBy((val) => { return !!val.matches; })(meta.summary);
 
       // Add parses data.
       meta.parse = {
-        numMatches: numMatches,
+        numMatches,
         numFilesMatched: _.keys(meta.summary).length
       };
 
@@ -349,10 +351,10 @@ Parse.prototype.getData = function (callback) {
     }),
 
     // Filter to 1+ matches.
-    _.pickBy(function (g) { return !!g.meta.parse.numMatches; }),
+    _.pickBy((g) => { return !!g.meta.parse.numMatches; }),
 
     // Filter to just `meta` unless verbose.
-    _.mapValues(function (g) { return opts.verbose ? g : g.meta; })
+    _.mapValues((g) => { return opts.verbose ? g : g.meta; })
   )(bundle.groups);
 
   // Metadata

--- a/lib/actions/pattern.js
+++ b/lib/actions/pattern.js
@@ -1,19 +1,19 @@
 "use strict";
 
-var util = require("util");
-var _ = require("lodash/fp");
+const util = require("util");
+const _ = require("lodash/fp");
 
-var Base = require("./base");
-var metaSum = require("../utils/data").metaSum;
+const Base = require("./base");
+const metaSum = require("../utils/data").metaSum;
 
-var FULL_MATCH_GROUP = 0; // Full matched group is at index 0.
+const FULL_MATCH_GROUP = 0; // Full matched group is at index 0.
 
 /**
  * Suspect patterns.
  *
  * For `--suspect-patterns`.
  */
-var SUSPECT_PATTERNS = {
+const SUSPECT_PATTERNS = {
   // Multiple Exports.
   //
   // ```js
@@ -40,7 +40,7 @@ var SUSPECT_PATTERNS = {
  *
  * @returns {void}
  */
-var Pattern = function Pattern() {
+const Pattern = function Pattern() {
   Base.apply(this, arguments);
 };
 
@@ -102,22 +102,22 @@ Pattern.prototype.tsvTemplate = _.template([
 ].join(""));
 
 Pattern.prototype.getData = function (callback) {
-  var opts = this.opts;
-  var bundle = this.bundle;
-  var codes = bundle.codes;
+  const opts = this.opts;
+  const bundle = this.bundle;
+  const codes = bundle.codes;
 
   // Inflate to regex objects of `{ [key], re }`
-  var patterns = [].concat(
+  const patterns = [].concat(
     // Suspect patterns
-    _.map.convert({ cap: false })(function (pat, key) {
+    _.map.convert({ cap: false })((pat, key) => {
       return {
-        key: key,
+        key,
         re: new RegExp(pat)
       };
     })(opts.suspectPatterns ? SUSPECT_PATTERNS : {}),
 
     // Patterns from user
-    _.map(function (pat) {
+    _.map((pat) => {
       return {
         re: new RegExp(pat)
       };
@@ -125,21 +125,21 @@ Pattern.prototype.getData = function (callback) {
   );
 
   // Create data object.
-  var data = _.flow(
+  const data = _.flow(
     // Mutate summary with pattern matches.
-    _.mapValues(function (group) {
-      var meta = group.meta;
+    _.mapValues((group) => {
+      const meta = group.meta;
 
       // Stateful counters.
-      var numMatches = 0;
+      let numMatches = 0;
 
       // Add matches, filter, and mutate summary.
       // eslint-disable-next-line lodash-fp/no-unused-result
       _.flow(
         // Map to match objects: `{ [key], re, index, match }`
-        _.flatMap(function (obj) {
+        _.flatMap((obj) => {
           // Try to match for all unique indexes in play.
-          return _.flatMap(function (idx) {
+          return _.flatMap((idx) => {
             return _.extend({
               index: idx,
               match: _.find({ id: idx })(codes)
@@ -149,13 +149,13 @@ Pattern.prototype.getData = function (callback) {
         }),
 
         // Only keep matches.
-        _.filter(function (obj) { return obj.match; }),
+        _.filter((obj) => { return obj.match; }),
 
         // Get number of matches.
-        _.tap(function (objs) { numMatches = objs.length; }),
+        _.tap((objs) => { numMatches = objs.length; }),
 
         // Map to final form and mutate summary: `{ [key], pattern, match }`
-        _.each(function (obj) {
+        _.each((obj) => {
           meta.summary[obj.index].matches = [].concat(
             meta.summary[obj.index].matches || [],
             [{
@@ -168,11 +168,11 @@ Pattern.prototype.getData = function (callback) {
       )(patterns);
 
       // Mutate summary to remove _unmatched_ indexes.
-      meta.summary = _.pickBy(function (val) { return !!val.matches; })(meta.summary);
+      meta.summary = _.pickBy((val) => { return !!val.matches; })(meta.summary);
 
       // Add pattern data.
       meta.pattern = {
-        numMatches: numMatches,
+        numMatches,
         numFilesMatched: _.keys(meta.summary).length
       };
 
@@ -180,10 +180,10 @@ Pattern.prototype.getData = function (callback) {
     }),
 
     // Filter to 1+ matches.
-    _.pickBy(function (g) { return !!g.meta.pattern.numMatches; }),
+    _.pickBy((g) => { return !!g.meta.pattern.numMatches; }),
 
     // Filter to just `meta` unless verbose.
-    _.mapValues(function (g) { return opts.verbose ? g : g.meta; })
+    _.mapValues((g) => { return opts.verbose ? g : g.meta; })
   )(bundle.groups);
 
   // Metadata

--- a/lib/actions/sizes.js
+++ b/lib/actions/sizes.js
@@ -1,15 +1,11 @@
 "use strict";
 
-const zlib = require("zlib");
 const util = require("util");
-
 const _ = require("lodash/fp");
-const uglify = require("uglify-js");
 
 const Base = require("./base");
+const Compressor = require("../utils/compressor");
 const toParseable = require("../utils/code").toParseable;
-
-const GZIP_OPTS = { level: 9 };
 
 /**
  * Sizes action abstraction.
@@ -24,44 +20,80 @@ util.inherits(Sizes, Base);
 
 Sizes.prototype.name = "duplicates";
 
-Sizes.prototype.textTemplate = _.template([
-  "inspectpack --action=sizes",
-  "==========================",
-  "",
-  "## Summary",
-  "",
-  "* Bundle:",
-  "    * Path:                    <%= opts.bundle %>",
-  "    * Bytes (min):             <%= meta.bundle.min %>",
-  "    * Bytes (min+gz):          <%= meta.bundle.minGz %>",
-  "",
-  "## Files                  <% _.each(function (obj) { %>",
-  "<%= obj.index %>. <%= obj.fileName %>",
-  "  * Type:          <%= obj.type %>",
-  "  * Size:          <%= obj.size.full %>",
-  "  * Size (min):    <%= obj.size.min %>",
-  "  * Size (min+gz): <%= obj.size.minGz %>",
-  "<% })(data.sizes); %>",
-  "",
-  ""
-].join("\n"));
+Sizes.prototype.textTemplate = _.template(
+  [
+    "inspectpack --action=sizes",
+    "==========================",
+    "",
+    "## Summary",
+    "",
+    "* Bundle:",
+    "    * Path:                    <%= opts.bundle %>",
+    "    * Bytes (min):             <%= meta.bundle.min %>",
+    "    * Bytes (min+gz):          <%= meta.bundle.minGz %>",
+    "",
+    "## Files                  <% _.each(function (obj) { %>",
+    "<%= obj.index %>. <%= obj.fileName %>",
+    "  * Type:          <%= obj.type %>",
+    "  * Size:          <%= obj.size.full %>",
+    "  * Size (min):    <%= obj.size.min %>",
+    "  * Size (min+gz): <%= obj.size.minGz %>",
+    "<% })(data.sizes); %>",
+    "",
+    ""
+  ].join("\n")
+);
 
-Sizes.prototype.tsvTemplate = _.template([
-  "Index\tFull Name\tShort Name\tType\tSize\tSize (min)\tSize (min+gz)\n",
-  "<% _.each(function (obj) { %>",
-  "<%= obj.index %>\t",
-  "<%= obj.fileName %>\t",
-  "<%= obj.baseName %>\t",
-  "<%= obj.type %>\t",
-  "<%= obj.size.full %>\t",
-  "<%= obj.size.min %>\t",
-  "<%= obj.size.minGz %>\n",
-  "<% })(data.sizes); %>"
-].join(""));
+Sizes.prototype.tsvTemplate = _.template(
+  [
+    "Index\tFull Name\tShort Name\tType\tSize\tSize (min)\tSize (min+gz)\n",
+    "<% _.each(function (obj) { %>",
+    "<%= obj.index %>\t",
+    "<%= obj.fileName %>\t",
+    "<%= obj.baseName %>\t",
+    "<%= obj.type %>\t",
+    "<%= obj.size.full %>\t",
+    "<%= obj.size.min %>\t",
+    "<%= obj.size.minGz %>\n",
+    "<% })(data.sizes); %>"
+  ].join("")
+);
+
+const getModuleSize = (obj, opts) => {
+  const minified = opts.minified;
+  const gzip = opts.gzip;
+
+  // Get code size for any type of chunk.
+  // Reinflate ref (`123`) or refs (`[123, 345]`) for size analysis.
+  let code = obj.code;
+  if (!obj.isCode()) {
+    const ref = obj.isSingleRef() ? obj.singleRef : obj.multiRefs;
+    code = JSON.stringify(ref);
+  }
+
+  return opts.compressor
+    .getSizes({
+      source: toParseable(code),
+      minified,
+      gzip
+    })
+    .then(sizes => ({
+      id: obj.id,
+      baseName: obj.baseName,
+      fileName: obj.fileName,
+      type: obj.isTemplate ? "template" : obj.type,
+      size: {
+        full: sizes.full,
+        min: obj.isCode() ? sizes.min : code.length,
+        minGz: obj.isCode() ? sizes.minGz : code.length
+      }
+    }));
+};
 
 Sizes.prototype.getData = function (callback) {
   // Options.
   const opts = this.opts;
+  const compressor = opts.compressor || new Compressor();
   const minified = opts.minified || opts.gzip;
   const gzip = opts.gzip;
 
@@ -70,68 +102,32 @@ Sizes.prototype.getData = function (callback) {
   const codes = bundle.codes;
 
   // Convert codes array to sizes array
-  const sizes = _.map((obj) => {
-    // Get code size for any type of chunk.
-    // Reinflate ref (`123`) or refs (`[123, 345]`) for size analysis.
-    let code = obj.code;
-    if (!obj.isCode()) {
-      const ref = obj.isSingleRef() ? obj.singleRef : obj.multiRefs;
-      code = JSON.stringify(ref);
-    }
-
-    // Min+gz sizes.
-    let minSize = "--";
-    let minGzSize = "--";
-    if (obj.isCode() && minified) {
-      const codeSrc = toParseable(code);
-      const minSrc = uglify.minify(codeSrc, {
-        fromString: true,
-        warnings: false,
-        output: {
-          // eslint-disable-next-line camelcase
-          max_line_len: Infinity
-        }
-      }).code;
-      minSize = minSrc.length;
-
-      if (gzip) {
-        minGzSize = zlib.gzipSync(minSrc, GZIP_OPTS).length;
-      }
-    }
-
-    return {
-      id: obj.id,
-      baseName: obj.baseName,
-      fileName: obj.fileName,
-      type: obj.isTemplate ? "template" : obj.type,
-      size: {
-        full: code.length,
-        min: obj.isCode() ? minSize : code.length,
-        minGz: obj.isCode() ? minGzSize : code.length
-      }
-    };
-  })(codes);
-
-  const bundleMinSrc = minified ? uglify.minify(bundle.code, {
-    fromString: true,
-    warnings: false,
-    output: {
-      // eslint-disable-next-line camelcase
-      max_line_len: Infinity
-    }
-  }).code : null;
-
-  callback(null, {
-    meta: {
-      // The existing total bundle.
-      bundle: {
-        full: bundle.code.length,
-        min: minified ? bundleMinSrc.length : "--",
-        minGz: gzip ? zlib.gzipSync(bundleMinSrc, GZIP_OPTS).length : "--"
-      }
-    },
-    sizes
-  });
+  Promise.all(
+    codes.map(code =>
+      getModuleSize(code, {
+        compressor,
+        minified,
+        gzip
+      }))
+  )
+    .then(sizes =>
+      Promise.all([
+        sizes,
+        compressor.getSizes({
+          source: bundle.code,
+          minified,
+          gzip
+        })
+      ]))
+    .then(result => ({
+      meta: {
+        // The existing total bundle.
+        bundle: result[1]
+      },
+      sizes: result[0]
+    }))
+    .then(sizes => callback(null, sizes))
+    .catch(err => callback(err, null));
 };
 
 /**

--- a/lib/actions/sizes.js
+++ b/lib/actions/sizes.js
@@ -1,22 +1,22 @@
 "use strict";
 
-var zlib = require("zlib");
-var util = require("util");
+const zlib = require("zlib");
+const util = require("util");
 
-var _ = require("lodash/fp");
-var uglify = require("uglify-js");
+const _ = require("lodash/fp");
+const uglify = require("uglify-js");
 
-var Base = require("./base");
-var toParseable = require("../utils/code").toParseable;
+const Base = require("./base");
+const toParseable = require("../utils/code").toParseable;
 
-var GZIP_OPTS = { level: 9 };
+const GZIP_OPTS = { level: 9 };
 
 /**
  * Sizes action abstraction.
  *
  * @returns {void}
  */
-var Sizes = function Sizes() {
+const Sizes = function Sizes() {
   Base.apply(this, arguments);
 };
 
@@ -61,30 +61,30 @@ Sizes.prototype.tsvTemplate = _.template([
 
 Sizes.prototype.getData = function (callback) {
   // Options.
-  var opts = this.opts;
-  var minified = opts.minified || opts.gzip;
-  var gzip = opts.gzip;
+  const opts = this.opts;
+  const minified = opts.minified || opts.gzip;
+  const gzip = opts.gzip;
 
   // Bundle.
-  var bundle = this.bundle;
-  var codes = bundle.codes;
+  const bundle = this.bundle;
+  const codes = bundle.codes;
 
   // Convert codes array to sizes array
-  var sizes = _.map(function (obj) {
+  const sizes = _.map((obj) => {
     // Get code size for any type of chunk.
     // Reinflate ref (`123`) or refs (`[123, 345]`) for size analysis.
-    var code = obj.code;
+    let code = obj.code;
     if (!obj.isCode()) {
-      var ref = obj.isSingleRef() ? obj.singleRef : obj.multiRefs;
+      const ref = obj.isSingleRef() ? obj.singleRef : obj.multiRefs;
       code = JSON.stringify(ref);
     }
 
     // Min+gz sizes.
-    var minSize = "--";
-    var minGzSize = "--";
+    let minSize = "--";
+    let minGzSize = "--";
     if (obj.isCode() && minified) {
-      var codeSrc = toParseable(code);
-      var minSrc = uglify.minify(codeSrc, {
+      const codeSrc = toParseable(code);
+      const minSrc = uglify.minify(codeSrc, {
         fromString: true,
         warnings: false,
         output: {
@@ -112,7 +112,7 @@ Sizes.prototype.getData = function (callback) {
     };
   })(codes);
 
-  var bundleMinSrc = minified ? uglify.minify(bundle.code, {
+  const bundleMinSrc = minified ? uglify.minify(bundle.code, {
     fromString: true,
     warnings: false,
     output: {
@@ -130,7 +130,7 @@ Sizes.prototype.getData = function (callback) {
         minGz: gzip ? zlib.gzipSync(bundleMinSrc, GZIP_OPTS).length : "--"
       }
     },
-    sizes: sizes
+    sizes
   });
 };
 

--- a/lib/actions/versions.js
+++ b/lib/actions/versions.js
@@ -1,30 +1,30 @@
 "use strict";
 /*eslint no-magic-numbers: ["error", { "ignore": [0, 1, -1] }]*/
 
-var path = require("path");
-var util = require("util");
-var _ = require("lodash/fp");
+const path = require("path");
+const util = require("util");
+const _ = require("lodash/fp");
 
-var Base = require("./base");
+const Base = require("./base");
 
-var MIN_NESTED_PATH_LENGTH = 2; // Ignore `./~` or `../~` since those are pointing to root modules
+const MIN_NESTED_PATH_LENGTH = 2; // Ignore `./~` or `../~` since those are pointing to root modules
 
-var isCodeANodeModule = function (code) {
+const isCodeANodeModule = function (code) {
   return code.fileName.indexOf("~/") !== -1;
 };
 
-var getSkewedPackageMap = function (packageMap) {
-  return _.pickBy(function (versionObj) {
+const getSkewedPackageMap = function (packageMap) {
+  return _.pickBy((versionObj) => {
     return Object.keys(versionObj).length > 1;
   })(packageMap);
 };
 
-var getModuleName = function (libPath) {
+const getModuleName = function (libPath) {
   // eslint-disable-next-line no-magic-numbers
   return _.take(libPath[0] === "@" ? 2 : 1)(libPath.split("/")).join("/");
 };
 
-var getPackageJSON = function (packagePath) {
+const getPackageJSON = function (packagePath) {
   try {
     return require(packagePath); // eslint-disable-line global-require
   } catch (err) {
@@ -32,9 +32,9 @@ var getPackageJSON = function (packagePath) {
   }
 };
 
-var addToDirStructure = function (currentDir, pathArray, packageJSON) {
+const addToDirStructure = function (currentDir, pathArray, packageJSON) {
   // get the first module from pathArray and mutate pathArray to remaining items
-  var firstModule = getModuleName(pathArray.shift());
+  const firstModule = getModuleName(pathArray.shift());
 
   if (!currentDir[firstModule]) {
     currentDir[firstModule] = {};
@@ -50,9 +50,9 @@ var addToDirStructure = function (currentDir, pathArray, packageJSON) {
   currentDir[firstModule].__packageJSON = packageJSON;
 };
 
-var getModulePath = function (depName, currentPathArray, dirStructure) {
-  var attemptedPathArray = currentPathArray.concat([depName]);
-  var moduleDir = _.get(attemptedPathArray)(dirStructure);
+const getModulePath = function (depName, currentPathArray, dirStructure) {
+  const attemptedPathArray = currentPathArray.concat([depName]);
+  const moduleDir = _.get(attemptedPathArray)(dirStructure);
 
   if (moduleDir) {
     return attemptedPathArray;
@@ -66,11 +66,11 @@ var getModulePath = function (depName, currentPathArray, dirStructure) {
   return getModulePath(depName, currentPathArray.slice(0, -1), dirStructure);
 };
 
-var addRequirePathToPackageMap = function (pkg, requirePath, pkgMap) {
+const addRequirePathToPackageMap = function (pkg, requirePath, pkgMap) {
   pkgMap[pkg.name] = pkgMap[pkg.name] || {};
 
   // Ensure array, add path, and filter to sorted uniques.
-  var updates = (pkgMap[pkg.name][pkg.version] || []).concat([requirePath]);
+  const updates = (pkgMap[pkg.name][pkg.version] || []).concat([requirePath]);
   pkgMap[pkg.name][pkg.version] = _.flow(
     _.uniq,
     _.sortBy(_.identity)
@@ -79,20 +79,20 @@ var addRequirePathToPackageMap = function (pkg, requirePath, pkgMap) {
   return pkgMap;
 };
 
-var getSkewedDepsWithGraphInfo = function (rootDirStructure, allPackagesInBundle) {
-  var packageMap = {};
-  var checkedModules = {};
-  var notFoundPackages = {};
-  var skewedPackageMap = {};
+const getSkewedDepsWithGraphInfo = function (rootDirStructure, allPackagesInBundle) {
+  let packageMap = {};
+  const checkedModules = {};
+  const notFoundPackages = {};
+  let skewedPackageMap = {};
 
-  var createCheckDepFunction = function (requiredByString, modulePath) {
+  const createCheckDepFunction = function (requiredByString, modulePath) {
     return function (depVersion, depName) {
       // Ignore any packages that aren't bundled
       if (!allPackagesInBundle[depName]) {
         return;
       }
 
-      var pathToModuleArray = getModulePath(depName, modulePath, rootDirStructure);
+      const pathToModuleArray = getModulePath(depName, modulePath, rootDirStructure);
 
       if (!pathToModuleArray) {
         // Add our requiredByString to the notFoundPackages since we don't know what version
@@ -113,11 +113,11 @@ var getSkewedDepsWithGraphInfo = function (rootDirStructure, allPackagesInBundle
     };
   };
 
-  var addDepToPackageMap = function (modulePath, requiredByString) {
-    var packageJSON = _.get(modulePath.concat(["__packageJSON"]))(rootDirStructure);
-    var packageName = packageJSON.name;
-    var packageVersion = packageJSON.version;
-    var packageString = packageName + "@" + packageVersion;
+  const addDepToPackageMap = function (modulePath, requiredByString) {
+    const packageJSON = _.get(modulePath.concat(["__packageJSON"]))(rootDirStructure);
+    const packageName = packageJSON.name;
+    const packageVersion = packageJSON.version;
+    const packageString = `${packageName }@${ packageVersion}`;
 
     packageMap = addRequirePathToPackageMap(
       packageJSON,
@@ -132,10 +132,10 @@ var getSkewedDepsWithGraphInfo = function (rootDirStructure, allPackagesInBundle
 
     checkedModules[packageString] = true;
 
-    requiredByString += requiredByString ? " -> " + packageString : "root";
+    requiredByString += requiredByString ? ` -> ${ packageString}` : "root";
 
     if (packageJSON.dependencies) {
-      var checkFn = createCheckDepFunction(requiredByString, modulePath);
+      const checkFn = createCheckDepFunction(requiredByString, modulePath);
       _.each.convert({ cap: false })(checkFn)(packageJSON.dependencies);
     }
   };
@@ -145,7 +145,7 @@ var getSkewedDepsWithGraphInfo = function (rootDirStructure, allPackagesInBundle
   skewedPackageMap = getSkewedPackageMap(packageMap);
 
   // Add lost puppies back to skewedPackageMap
-  _.each.convert({ cap: false })(function (consumerList, depName) {
+  _.each.convert({ cap: false })((consumerList, depName) => {
     if (skewedPackageMap[depName]) {
       skewedPackageMap[depName].unknownResolvedVersion = consumerList;
     }
@@ -154,14 +154,14 @@ var getSkewedDepsWithGraphInfo = function (rootDirStructure, allPackagesInBundle
   return skewedPackageMap;
 };
 
-var mapToSortedSkewedArray = function (skewedDepMap, allPackages) {
-  return _.sortBy(function (obj) {
+const mapToSortedSkewedArray = function (skewedDepMap, allPackages) {
+  return _.sortBy((obj) => {
     return obj.skewedDeps.length;
-  })(Object.keys(skewedDepMap).map(function (depName) {
-    var subDepsWithSkew = [];
+  })(Object.keys(skewedDepMap).map((depName) => {
+    let subDepsWithSkew = [];
 
-    Object.keys(skewedDepMap[depName]).forEach(function (version) {
-      var deps = allPackages[depName][version] && allPackages[depName][version].dependencies;
+    Object.keys(skewedDepMap[depName]).forEach((version) => {
+      const deps = allPackages[depName][version] && allPackages[depName][version].dependencies;
 
       if (deps) {
         subDepsWithSkew = _.uniq(
@@ -180,8 +180,8 @@ var mapToSortedSkewedArray = function (skewedDepMap, allPackages) {
   }));
 };
 
-var getSortedSkewedDepArray = function (dirStructure, allPackagesInBundle) {
-  var skewedDepsWithGraphInfo = getSkewedDepsWithGraphInfo(
+const getSortedSkewedDepArray = function (dirStructure, allPackagesInBundle) {
+  const skewedDepsWithGraphInfo = getSkewedDepsWithGraphInfo(
     dirStructure,
     allPackagesInBundle
   );
@@ -194,7 +194,7 @@ var getSortedSkewedDepArray = function (dirStructure, allPackagesInBundle) {
  *
  * @returns {void}
  */
-var Versions = function Versions() {
+const Versions = function Versions() {
   Base.apply(this, arguments);
 };
 
@@ -239,16 +239,16 @@ Versions.prototype.tsvTemplate = _.template([
 
 /*eslint-disable max-statements*/
 Versions.prototype.getData = function (callback) {
-  var pathRoot = path.resolve(this.opts.root);
-  var codes = this.bundle.codes;
+  const pathRoot = path.resolve(this.opts.root);
+  const codes = this.bundle.codes;
 
-  var allPackagesInBundle = {};
-  var dirStructure = {};
+  const allPackagesInBundle = {};
+  const dirStructure = {};
 
   // In the split path array, whatever comes before the first ~/ is the bundle location from root.
-  var bundleLocationFromRoot = _.find(isCodeANodeModule)(codes).fileName.split("~/")[0];
-  var rootPackageJSONPath = path.join(pathRoot, bundleLocationFromRoot, "package.json");
-  var rootPackageJSON = getPackageJSON(rootPackageJSONPath);
+  const bundleLocationFromRoot = _.find(isCodeANodeModule)(codes).fileName.split("~/")[0];
+  const rootPackageJSONPath = path.join(pathRoot, bundleLocationFromRoot, "package.json");
+  const rootPackageJSON = getPackageJSON(rootPackageJSONPath);
 
   // Mutate outside variables.
   // eslint-disable-next-line lodash-fp/no-unused-result
@@ -257,21 +257,24 @@ Versions.prototype.getData = function (callback) {
     _.filter(isCodeANodeModule),
 
     // Reduce to a map of {<packageName>: {<versionNumber>: <PathInfo>}}
-    _.reduce(function (packageMap, code) {
-      var packagePathArray = code.fileName.split("~/");
+    _.reduce((packageMap, code) => {
+      const packagePathArray = code.fileName.split("~/");
 
-      var fileString = getModuleName(packagePathArray[packagePathArray.length - 1]);
+      const fileString = getModuleName(packagePathArray[packagePathArray.length - 1]);
 
       packagePathArray[packagePathArray.length - 1] = fileString;
 
       // We either know where it came from or it was flattened to top level node_modules.
-      var currentPathNormalized = packagePathArray.length > MIN_NESTED_PATH_LENGTH ?
+      const currentPathNormalized = packagePathArray.length > MIN_NESTED_PATH_LENGTH ?
         packagePathArray.slice(1, packagePathArray.length - 1).join(" -> ") :
         "Root";
 
-      var packagePath = path.join(pathRoot, packagePathArray.join("node_modules/"), "package.json");
+      const packagePath = path.join(
+        pathRoot,
+        packagePathArray.join("node_modules/"
+      ), "package.json");
 
-      var packageJSON = getPackageJSON(packagePath);
+      const packageJSON = getPackageJSON(packagePath);
 
       if (!packageJSON) {
         return packageMap;
@@ -313,10 +316,10 @@ Versions.prototype.getData = function (callback) {
   // We check for all packages that are in the bundle but not at root level.
   // If there is only one version of that package in the bundle we can safely add it to root
   // Because we know it matches the version that exists at root in the file system
-  var dedupedToNested = _.difference(Object.keys(allPackagesInBundle))(Object.keys(dirStructure));
+  const dedupedToNested = _.difference(Object.keys(allPackagesInBundle))(Object.keys(dirStructure));
 
-  dedupedToNested.forEach(function (depName) {
-    var versions = Object.keys(allPackagesInBundle[depName]);
+  dedupedToNested.forEach((depName) => {
+    const versions = Object.keys(allPackagesInBundle[depName]);
 
     if (versions.length === 1) {
       dirStructure[depName] = {};
@@ -331,34 +334,34 @@ Versions.prototype.getData = function (callback) {
   dirStructure.__packageJSON = rootPackageJSON;
 
   // Finish data processing.
-  var data = getSortedSkewedDepArray(dirStructure, allPackagesInBundle);
+  const data = getSortedSkewedDepArray(dirStructure, allPackagesInBundle);
 
   // Filter to missed deduplication opportunities.
   if (this.opts.duplicates) {
     // Lazy require to avoid potential future circular dependencies.
-    var Duplicates = require("./duplicates").Duplicates; // eslint-disable-line global-require
-    var dups = new Duplicates({
+    const Duplicates = require("./duplicates").Duplicates; // eslint-disable-line global-require
+    const dups = new Duplicates({
       opts: {}, // Use default options here.
       bundle: this.bundle
     });
 
-    dups.getData(function (err, dupsData) {
+    dups.getData((err, dupsData) => {
       if (err) {
         callback(err);
         return;
       }
 
       // Collapse the duplicate files to just the module names.
-      var dupLibs = _.flow(
+      const dupLibs = _.flow(
         _.keys,
-        _.reject(function (k) { return k === "meta"; }),
+        _.reject((k) => { return k === "meta"; }),
         _.map(getModuleName),
         _.uniq
       )(dupsData);
 
       // Filter data to duplicate libraries only.
       callback(null, {
-        versions: _.filter(function (o) { return _.contains(o.name)(dupLibs); })(data)
+        versions: _.filter((o) => { return _.contains(o.name)(dupLibs); })(data)
       });
     });
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -1,12 +1,12 @@
 "use strict";
 
-var pkg = require("../package.json");
-var yargs = require("yargs");
+const pkg = require("../package.json");
+const yargs = require("yargs");
 
-var TERMINAL_CHARS = 100;
-var NOT_FOUND = -1;
+const TERMINAL_CHARS = 100;
+const NOT_FOUND = -1;
 
-var ACTIONS = Object.keys(require("./actions").ACTIONS);
+const ACTIONS = Object.keys(require("./actions").ACTIONS);
 
 /**
  * Validation wrapper
@@ -14,21 +14,21 @@ var ACTIONS = Object.keys(require("./actions").ACTIONS);
  * @param {Object} parser yargs parser object
  * @returns {void}
  */
-var Validate = function Validate(parser) {
+const Validate = function Validate(parser) {
   this.parser = parser;
   this.argv = parser.argv;
 };
 
 Validate.prototype = {
-  _fail: function (msgOrErr) {
+  _fail(msgOrErr) {
     this.parser.showHelp();
-    var err = msgOrErr instanceof Error ? msgOrErr : new Error(msgOrErr);
+    const err = msgOrErr instanceof Error ? msgOrErr : new Error(msgOrErr);
     throw err;
   },
 
   /*eslint-disable complexity,max-statements*/
-  action: function () {
-    var action = this.argv.action;
+  action() {
+    const action = this.argv.action;
 
     if (!this.argv.bundle && ACTIONS.indexOf(action) === NOT_FOUND) {
       this._fail("Requires `--bundle` file");
@@ -63,9 +63,9 @@ Validate.prototype = {
 
 // Args wrapper.
 module.exports = {
-  parse: function () {
+  parse() {
     return yargs
-      .usage(pkg.description + "\n\nUsage: inspectpack --action=<string> [options]")
+      .usage(`${pkg.description }\n\nUsage: inspectpack --action=<string> [options]`)
 
       // Actions
       .option("action", {
@@ -170,7 +170,7 @@ module.exports = {
       .strict();
   },
 
-  validate: function (parser) {
+  validate(parser) {
     return new Validate(parser)
       .action()
       .argv;

--- a/lib/daemon/index.js
+++ b/lib/daemon/index.js
@@ -1,11 +1,11 @@
 "use strict";
 
 const path = require("path");
-const farmhash = require("farmhash");
 const workerpool = require("workerpool");
 
 const actions = require("../actions");
 const Cache = require("../utils/cache");
+const hash = require("../utils/hash");
 
 class InspectpackDaemon {
   static init(opts) {
@@ -35,7 +35,7 @@ class InspectpackDaemon {
 
 Object.keys(actions.ACTIONS).forEach(action => {
   InspectpackDaemon.prototype[action] = function (opts) {
-    const hashedKey = farmhash.hash64(JSON.stringify({ action, opts }));
+    const hashedKey = hash({ action, opts });
 
     if (this._cache) {
       const cachedValue = this._cache.get(hashedKey);

--- a/lib/daemon/index.js
+++ b/lib/daemon/index.js
@@ -8,6 +8,13 @@ const Cache = require("../utils/cache");
 const hash = require("../utils/hash");
 
 class InspectpackDaemon {
+  /**
+   * Start the daemon with an asynchronously initialized cache.
+   *
+   * @param {Object} opts                  Object options
+   * @param {Object} opts.cacheDir         The directory to store cache files in
+   * @returns {Promise<InspectpackDaemon>} The daemon with cache
+   */
   static init(opts) {
     opts = opts || {};
 
@@ -19,6 +26,13 @@ class InspectpackDaemon {
     );
   }
 
+  /**
+   * Start the daemon with either no cache or an existing cache.
+   *
+   * @param {Cache} cache                  An existing cache instance
+   * @param {Object} opts                  Object options
+   * @param {Object} opts.cacheDir         The directory to store cache files in
+   */
   constructor(cache, opts) {
     this._cache = cache || null;
     this._cacheDir = opts.cacheDir || null;
@@ -29,11 +43,18 @@ class InspectpackDaemon {
     });
   }
 
+  /**
+   * Terminate the daemon.
+   *
+   * @returns {void}
+   */
   terminate() {
     this._pool.clear();
   }
 }
 
+// Attach a method per corresponding action to the prototype.
+// The generated methods look like `daemon.sizes(...).then(...)`
 Object.keys(actions.ACTIONS).forEach(action => {
   InspectpackDaemon.prototype[action] = function (opts) {
     const hashedKey = hash({ action, opts });

--- a/lib/daemon/index.js
+++ b/lib/daemon/index.js
@@ -23,8 +23,9 @@ class InspectpackDaemon {
     this._cache = cache || null;
     this._cacheDir = opts.cacheDir || null;
     this._pool = workerpool.pool(path.resolve(__dirname, "worker.js"), {
-      minWorkers: "max",
-      maxWorkers: 1
+      minWorkers: 1,
+      maxWorkers: 1,
+      forkArgs: [`cacheDir=${this._cacheDir}`]
     });
   }
 

--- a/lib/daemon/index.js
+++ b/lib/daemon/index.js
@@ -1,0 +1,57 @@
+"use strict";
+
+const path = require("path");
+const farmhash = require("farmhash");
+const workerpool = require("workerpool");
+
+const actions = require("../actions");
+const Cache = require("../utils/cache");
+
+class InspectpackDaemon {
+  static init(opts) {
+    opts = opts || {};
+
+    return Cache.init({
+      scope: "action-results",
+      cacheDir: opts.cacheDir
+    }).then(
+      cache => new InspectpackDaemon(cache, opts)
+    );
+  }
+
+  constructor(cache, opts) {
+    this._cache = cache || null;
+    this._cacheDir = opts.cacheDir || null;
+    this._pool = workerpool.pool(path.resolve(__dirname, "worker.js"), {
+      minWorkers: "max",
+      maxWorkers: 1
+    });
+  }
+
+  terminate() {
+    this._pool.clear();
+  }
+}
+
+Object.keys(actions.ACTIONS).forEach(action => {
+  InspectpackDaemon.prototype[action] = function (opts) {
+    const hashedKey = farmhash.hash64(JSON.stringify({ action, opts }));
+
+    if (this._cache) {
+      const cachedValue = this._cache.get(hashedKey);
+      if (cachedValue) {
+        return Promise.resolve(cachedValue);
+      }
+    }
+
+    return this._pool.exec(action, [opts]).then(result => {
+      if (this._cache) {
+        this._cache.set(hashedKey, result);
+        this._cache.save();
+      }
+      return result;
+    });
+  };
+});
+
+module.exports = InspectpackDaemon;

--- a/lib/daemon/worker.js
+++ b/lib/daemon/worker.js
@@ -5,25 +5,35 @@ const workerpool = require("workerpool");
 const actions = require("../actions");
 const Compressor = require("../utils/compressor");
 
+const cacheDirArg = process.argv
+  .find(arg => arg.indexOf("cacheDir=") !== -1);
+const cacheDir = cacheDirArg && cacheDirArg
+  .replace("cacheDir=", "");
+
+const wrapMethod = (action, compressor) => args =>
+  new Promise((resolve, reject) =>
+    actions(action)(
+      Object.assign({}, args, { compressor }),
+      (err, result) => {
+        if (err) {
+          return reject(err);
+        }
+        compressor.saveCache();
+        return resolve(result);
+      }
+    ));
+
 Promise.all(
   Object.keys(actions.ACTIONS).map(action =>
     Compressor.init({
-      scope: `${action}-compressor`
+      scope: `${action}-compressor`,
+      cacheDir
     }).then(compressor => ({
-      [action]: args =>
-        new Promise((resolve, reject) =>
-          actions(action)(
-            Object.assign({}, args, { compressor }),
-            (err, result) => {
-              if (err) {
-                return reject(err);
-              }
-              compressor.saveCache();
-              return resolve(result);
-            }
-          ))
+      [action]: wrapMethod(action, compressor)
     })))
 )
   .then(actionMaps =>
-    actionMaps.reduce((acc, map) => Object.assign({}, acc, map), {}))
+    actionMaps.reduce((acc, map) =>
+      Object.assign({}, acc, map), {})
+    )
   .then(workerpool.worker);

--- a/lib/daemon/worker.js
+++ b/lib/daemon/worker.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const workerpool = require("workerpool");
+
+const actions = require("../actions");
+const Compressor = require("../utils/compressor");
+
+Promise.all(
+  Object.keys(actions.ACTIONS).map(action =>
+    Compressor.init({
+      scope: `${action}-compressor`
+    }).then(compressor => ({
+      [action]: args =>
+        new Promise((resolve, reject) =>
+          actions(action)(
+            Object.assign({}, args, { compressor }),
+            (err, result) => {
+              if (err) {
+                return reject(err);
+              }
+              compressor.saveCache();
+              return resolve(result);
+            }
+          ))
+    })))
+)
+  .then(actionMaps =>
+    actionMaps.reduce((acc, map) => Object.assign({}, acc, map), {}))
+  .then(workerpool.worker);

--- a/lib/daemon/worker.js
+++ b/lib/daemon/worker.js
@@ -10,6 +10,8 @@ const cacheDirArg = process.argv
 const cacheDir = cacheDirArg && cacheDirArg
   .replace("cacheDir=", "");
 
+// Create worker methods for each corresponding action.
+// The generated methods look like `sizes(...).then(...)`
 const wrapMethod = (action, compressor) => args =>
   new Promise((resolve, reject) =>
     actions(action)(
@@ -23,6 +25,8 @@ const wrapMethod = (action, compressor) => args =>
       }
     ));
 
+// Create each action method, injecting a compressor
+// instance for each one.
 Promise.all(
   Object.keys(actions.ACTIONS).map(action =>
     Compressor.init({

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 module.exports = {
   /*eslint-disable global-require*/
   args: require("./args"),
-  actions: require("./actions")
+  actions: require("./actions"),
+  daemon: require("./daemon")
   /*eslint-enable global-require*/
 };

--- a/lib/models/bundle.js
+++ b/lib/models/bundle.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var fs = require("fs");
-var _ = require("lodash/fp");
-var parse = require("../utils/parser");
+const fs = require("fs");
+const _ = require("lodash/fp");
+const parse = require("../utils/parser");
 
 /**
  * Bundle abstraction.
@@ -15,9 +15,9 @@ var parse = require("../utils/parser");
  * @param {String}    opts.code Raw JavaScript code
  * @returns {void}
  */
-var Bundle = module.exports = function Bundle(opts) {
+const Bundle = module.exports = function Bundle(opts) {
   this.code = opts.code;
-  this.codes = parse(opts.code).filter(function (code) {
+  this.codes = parse(opts.code).filter((code) => {
     return !code.isNothingRef() && !code.isUnknown();
   });
   this.groups = _.flow(
@@ -36,32 +36,32 @@ var Bundle = module.exports = function Bundle(opts) {
  * @returns {void}
  */
 Bundle.prototype.validate = function () {
-  var codes = this.codes;
+  const codes = this.codes;
 
   if (codes.length === 0) {
     throw new Error("No code sections found");
   }
 
-  codes.forEach(function (code) {
+  codes.forEach((code) => {
     // Single number refs -> real code.
     if (code.isSingleRef()) {
-      var singleRef = _.find({ id: code.singleRef })(codes);
+      const singleRef = _.find({ id: code.singleRef })(codes);
       if (!singleRef.code) {
         throw new Error(
-          "Expected: " + JSON.stringify(code) + " to reference code section." +
-          "\nFound non-code: " + JSON.stringify(singleRef));
+          `Expected: ${ JSON.stringify(code) } to reference code section.` +
+          `\nFound non-code: ${ JSON.stringify(singleRef)}`);
       }
     }
 
     // Array of refs -> code, template, ref, array of refs.
     // _Not_ empty.
     if (code.isMultiRef()) {
-      code.multiRefs.forEach(function (tmplRef) {
-        var multiRef = _.find({ id: tmplRef })(codes);
+      code.multiRefs.forEach((tmplRef) => {
+        const multiRef = _.find({ id: tmplRef })(codes);
         if (!multiRef.code.trim()) {
           throw new Error(
-            "Expected: " + JSON.stringify(code) + " to be non-empty." +
-            "\nFound: " + JSON.stringify(multiRef));
+            `Expected: ${ JSON.stringify(code) } to be non-empty.` +
+            `\nFound: ${ JSON.stringify(multiRef)}`);
         }
       });
     }
@@ -76,23 +76,23 @@ Bundle.prototype.validate = function () {
 Bundle.prototype._groupByType = function () {
   return _.flow(
     // Group by the base library name.
-    _.groupBy(function (code) { return code.baseName; }),
+    _.groupBy((code) => { return code.baseName; }),
 
     // Group into code, template, ref, refs.
-    _.mapValues(function (codes) {
+    _.mapValues((codes) => {
       return {
-        code: _.filter(function (code) {
+        code: _.filter((code) => {
           return code.isCode() && !code.isTemplate;
         })(codes),
         template: _.filter({ isTemplate: true })(codes),
         singleRef: _.flow(
-          _.filter(function (code) {
+          _.filter((code) => {
             return code.isSingleRef();
           }),
           _.map(_.omit("code"))
         )(codes),
         multiRefs: _.flow(
-          _.filter(function (code) {
+          _.filter((code) => {
             return code.isMultiRef();
           }),
           _.map(_.omit("code"))
@@ -108,22 +108,22 @@ Bundle.prototype._groupByType = function () {
  * @return {Function}     Mutates object values
  */
 Bundle.prototype._addGroupMetadata = function () {
-  var codesToFileNames = _.mapValues(_.map(function (code) {
+  const codesToFileNames = _.mapValues(_.map((code) => {
     return code.fileName;
   }));
 
-  return _.mapValues(function (group) {
+  return _.mapValues((group) => {
     // All of the indexes for ultimate references.
-    var meta = {
+    const meta = {
       // Code indexes for this group.
       codeIdxs: _.flow(
-        _.groupBy(function (code) { return code.id; }),
+        _.groupBy((code) => { return code.id; }),
         codesToFileNames
       )(group.code),
 
       // Unique internal/external code references for the group.
       singleRefIdxs: _.flow(
-        _.groupBy(function (code) { return code.singleRef; }),
+        _.groupBy((code) => { return code.singleRef; }),
         codesToFileNames
       )(group.singleRef),
 
@@ -132,14 +132,14 @@ Bundle.prototype._addGroupMetadata = function () {
       // The **first** element of a multi-refs array
       // refers to a template that contains the code involved.
       multiRefsIdxs: _.flow(
-        _.groupBy(function (code) { return _.first(code.multiRefs); }),
+        _.groupBy((code) => { return _.first(code.multiRefs); }),
         codesToFileNames
       )(group.multiRefs)
     };
 
     // More than one unique of _any_ means missed duplicates.
     meta.uniqIdxs = _.flow(
-      _.map(function (i) { return parseInt(i, 10); }),
+      _.map((i) => { return parseInt(i, 10); }),
       _.uniq
     )([].concat(
       _.keys(meta.codeIdxs),
@@ -149,8 +149,8 @@ Bundle.prototype._addGroupMetadata = function () {
 
     // Summary. Mostly for display.
     meta.summary = _.flow(
-      _.map(function (idx) {
-        var codePath = meta.codeIdxs[idx]
+      _.map((idx) => {
+        const codePath = meta.codeIdxs[idx]
           ? _.first(meta.codeIdxs[idx]) : null;
 
         return [idx, {
@@ -165,7 +165,7 @@ Bundle.prototype._addGroupMetadata = function () {
       _.fromPairs
     )(meta.uniqIdxs);
 
-    return _.extend({ meta: meta }, group);
+    return _.extend({ meta }, group);
   });
 };
 
@@ -175,18 +175,18 @@ Bundle.prototype._addGroupMetadata = function () {
  * @return {Function}   Iterator for grouped object
  */
 Bundle.prototype._validateGroups = function () {
-  var codes = this.codes;
+  const codes = this.codes;
 
   /* eslint-disable max-statements */ // Validation can be long and tortured.
-  return _.mapValues(function (group) {
+  return _.mapValues((group) => {
     // Templates: Should not have any code, ref, or refs.
-    var tmplLen = group.template.length;
+    const tmplLen = group.template.length;
     if (group.template.length) {
       if (tmplLen !== 1) { // eslint-disable-line no-magic-numbers
         // Same base name should never have more than 1 template.
-        throw new Error("Found 2+ templates: " + JSON.stringify(group));
+        throw new Error(`Found 2+ templates: ${ JSON.stringify(group)}`);
       } else if (group.code.length || group.singleRef.length || group.multiRefs.length) {
-        throw new Error("Found template with code|ref|refs: " + JSON.stringify(group));
+        throw new Error(`Found template with code|ref|refs: ${ JSON.stringify(group)}`);
       }
 
       return group;
@@ -200,35 +200,35 @@ Bundle.prototype._validateGroups = function () {
     // -  `960:lodash/_baseProperty.js` -> number `684`
     // - `2203:lodash/_baseProperty.js` -> number `684`
     // - `2409:lodash/_baseProperty.js` -> number `684`
-    var extraRef = _.difference(group.meta.singleRefIdxs, group.meta.codeIdxs);
+    const extraRef = _.difference(group.meta.singleRefIdxs, group.meta.codeIdxs);
     if (extraRef.length === 1) { // eslint-disable-line no-magic-numbers
       // Look up and check the extra item.
-      var singleExtraRef = _.first(extraRef);
-      var singleRefItem = _.find({ id: singleExtraRef })(codes);
+      const singleExtraRef = _.first(extraRef);
+      const singleRefItem = _.find({ id: singleExtraRef })(codes);
       if (!singleRefItem.isCode()) {
-        throw new Error("Found non-code reference: " + JSON.stringify(singleRefItem) +
-          "\nFor: " + JSON.stringify(group));
+        throw new Error(`Found non-code reference: ${ JSON.stringify(singleRefItem)
+          }\nFor: ${ JSON.stringify(group)}`);
       }
     } else if (extraRef.length > 1) { // eslint-disable-line no-magic-numbers
-      throw new Error("2+ extra ref indexes: " + JSON.stringify(extraRef) +
-        "\nItem: " + JSON.stringify(group));
+      throw new Error(`2+ extra ref indexes: ${ JSON.stringify(extraRef)
+        }\nItem: ${ JSON.stringify(group)}`);
     }
 
     // Check multi-references.
     //
     // Here, we _can_ have 2+ templates, which are missed duplicates.
-    var multiRefsIdxs = _.flow(
-      _.map(function (code) { return _.first(code.multiRefs); }),
+    const multiRefsIdxs = _.flow(
+      _.map((code) => { return _.first(code.multiRefs); }),
       _.uniq
     )(group.multiRefs);
 
     if (multiRefsIdxs.length) {
       // Each refs index should be a template.
-      _.each(function (refsIdx) {
-        var multiRefsItem = _.find({ id: refsIdx })(codes);
+      _.each((refsIdx) => {
+        const multiRefsItem = _.find({ id: refsIdx })(codes);
         if (!multiRefsItem.isTemplate) {
-          throw new Error("Found non-template reference: " + JSON.stringify(multiRefsItem) +
-            "\nFor: " + JSON.stringify(group));
+          throw new Error(`Found non-template reference: ${ JSON.stringify(multiRefsItem)
+            }\nFor: ${ JSON.stringify(group)}`);
         }
       })(multiRefsIdxs);
     }
@@ -262,8 +262,8 @@ Bundle.create = function (opts, callback) {
 
   if (opts.code) {
     // Prevent Zalgo by executing on the next tick.
-    return setImmediate(function () {
-      var bundle = new Bundle({
+    return setImmediate(() => {
+      const bundle = new Bundle({
         code: opts.code
       });
 
@@ -273,14 +273,14 @@ Bundle.create = function (opts, callback) {
     });
   }
 
-  return fs.readFile(opts.bundle, function (err, data) {
+  return fs.readFile(opts.bundle, (err, data) => {
     if (err) {
       callback(err);
       return;
     }
 
     // Create and validate.
-    var bundle = new Bundle({
+    const bundle = new Bundle({
       code: data.toString()
     });
 

--- a/lib/models/code.js
+++ b/lib/models/code.js
@@ -1,5 +1,7 @@
-var _ = require("lodash/fp");
-var moduleTypes = require("./module-types");
+"use strict";
+
+const _ = require("lodash/fp");
+const moduleTypes = require("./module-types");
 
 /**
  * Webpack code section abstraction
@@ -13,7 +15,7 @@ var moduleTypes = require("./module-types");
  * @param {Array<Number>}    opts.multiRefs The array of numeric refs of the module
  * @returns {void}
  */
-var Code = function Code(opts) {
+const Code = function Code(opts) {
   this.id = opts.id;
   this.fileName = opts.fileName;
   this.type = opts.type;

--- a/lib/utils/cache.js
+++ b/lib/utils/cache.js
@@ -18,7 +18,9 @@ const access = Promise.promisify(fs.access);
 // http://2ality.com/2015/08/es6-map-json.html#converting-a-string-map-to-and-from-an-object
 function serializeMap(stringKeyedMap) {
   const plainObject = Object.create(null);
-  for (const [key, value] of stringKeyedMap) {
+  for (const pair of stringKeyedMap.entries()) {
+    const key = pair[0];
+    const value = pair[1];
     plainObject[key] = value;
   }
   return JSON.stringify(plainObject);

--- a/lib/utils/cache.js
+++ b/lib/utils/cache.js
@@ -53,11 +53,14 @@ function getCacheFilePath(opts) {
 }
 
 module.exports = class Cache {
-  constructor(opts, map) {
-    this._opts = opts;
-    this._cache = map || new Map();
-  }
-
+  /**
+   * Asynchronously create a new cache from disk.
+   *
+   * @param   {Object} opts                  Object options
+   * @param   {Object} opts.scope            The prefix for this cache's file
+   * @param   {Object} opts.cacheDir         The directory to store cache files
+   * @returns {Promise<Cache>}               The hydrated cache
+   */
   static init(opts) {
     opts = opts || {};
 
@@ -67,15 +70,46 @@ module.exports = class Cache {
       .catch(() => new Cache(opts));
   }
 
+  /**
+   * An in-memory cache that can serialize to, and deserialize from, disk.
+   *
+   * @param {Object} opts                  Object options
+   * @param {Object} opts.scope            The prefix for this cache's file
+   * @param {Object} opts.cacheDir         The directory to store cache files
+   * @param {Map}    map                   An existing Map instance
+   */
+  constructor(opts, map) {
+    this._opts = opts;
+    this._cache = map || new Map();
+  }
+
+  /**
+   * Save the cache to disk.
+   *
+   * @returns {void}
+   */
   save() {
     return getCacheFilePath(this._opts).then(filePath =>
       writeFile(filePath, serializeMap(this._cache)));
   }
 
+  /**
+   * Retrive a value from the cache by key.
+   *
+   * @param   {string} key The key of the record to retrieve
+   * @returns {any}    The cached value
+   */
   get(key) {
     return this._cache.get(key) || null;
   }
 
+  /**
+   * Retrive a value from the cache by key.
+   *
+   * @param   {string}  key   The key of the record to set
+   * @param   {any}     value The value to set
+   * @returns {void}
+   */
   set(key, value) {
     this._cache.set(key, value);
   }

--- a/lib/utils/cache.js
+++ b/lib/utils/cache.js
@@ -1,0 +1,80 @@
+"use strict";
+
+const path = require("path");
+const fs = require("fs");
+const tmpdir = require("os").tmpdir;
+
+const Promise = require("bluebird");
+const mkdirp = Promise.promisify(require("mkdirp"));
+const toPairs = require("lodash/fp/toPairs");
+
+const DEFAULT_FILENAME = "default-cache.json";
+
+const readFile = Promise.promisify(fs.readFile);
+const writeFile = Promise.promisify(fs.writeFile);
+const access = Promise.promisify(fs.access);
+
+// Function adapted from:
+// http://2ality.com/2015/08/es6-map-json.html#converting-a-string-map-to-and-from-an-object
+function serializeMap(stringKeyedMap) {
+  const plainObject = Object.create(null);
+  for (const [key, value] of stringKeyedMap) {
+    plainObject[key] = value;
+  }
+  return JSON.stringify(plainObject);
+}
+
+// Adapted from interlock with permission:
+// https://github.com/interlockjs/interlock/blob/master/src/optimizations/file-cache/index.js
+function getCacheFilePath(opts) {
+  const canonicalPath = opts.cacheDir || tmpdir();
+
+  const initPath = opts.cacheDir
+    ? mkdirp(canonicalPath)
+    : Promise.resolve();
+
+  return initPath
+    // eslint-disable-next-line no-bitwise
+    .then(() => access(canonicalPath, fs.R_OK | fs.W_OK))
+    .then(() =>
+      path.join(
+        canonicalPath,
+        opts.scope || DEFAULT_FILENAME
+      ))
+    .catch(() => {
+      throw new Error(
+        `Unable to access cache directory.
+        Please check the directory's user permissions:
+        ${canonicalPath}`
+      );
+    });
+}
+
+module.exports = class Cache {
+  constructor(opts, map) {
+    this._opts = opts;
+    this._cache = map || new Map();
+  }
+
+  static init(opts) {
+    opts = opts || {};
+
+    return getCacheFilePath(opts)
+      .then(filePath => readFile(filePath, "utf8"))
+      .then(file => new Cache(opts, new Map(toPairs(JSON.parse(file)))))
+      .catch(() => new Cache(opts));
+  }
+
+  save() {
+    return getCacheFilePath(this._opts).then(filePath =>
+      writeFile(filePath, serializeMap(this._cache)));
+  }
+
+  get(key) {
+    return this._cache.get(key) || null;
+  }
+
+  set(key, value) {
+    this._cache.set(key, value);
+  }
+};

--- a/lib/utils/code.js
+++ b/lib/utils/code.js
@@ -28,6 +28,6 @@ module.exports = {
    * @returns {String}   Parseable code
    */
   toParseable(src) {
-    return `a=${ src.trim().replace(/,$/, "")}`;
+    return `a=${src.trim().replace(/,$/, "")}`;
   }
 };

--- a/lib/utils/code.js
+++ b/lib/utils/code.js
@@ -27,7 +27,7 @@ module.exports = {
    * @param {String} src Source code
    * @returns {String}   Parseable code
    */
-  toParseable: function (src) {
-    return "a=" + src.trim().replace(/,$/, "");
+  toParseable(src) {
+    return `a=${ src.trim().replace(/,$/, "")}`;
   }
 };

--- a/lib/utils/compressor.js
+++ b/lib/utils/compressor.js
@@ -41,10 +41,13 @@ const getMinifiedLength = opts =>
   minify(opts).then(result => result.code && result.code.length);
 
 module.exports = class Compressor {
-  constructor(cache) {
-    this._cache = cache || null;
-  }
-
+  /**
+   * Start the compressor with an asynchronously initialized cache.
+   *
+   * @param   {Object} opts          Object options
+   * @param   {Object} opts.cacheDir The directory to store cache files in
+   * @returns {Promise<Compressor>}  The compressor with cache
+   */
   static init(opts) {
     opts = opts || {};
 
@@ -54,12 +57,38 @@ module.exports = class Compressor {
     }).then(cache => new Compressor(cache));
   }
 
+  /**
+   * A centralized manager for uglifying, gzipping, and retrieving file sizes.
+   *
+   * @param   {Cache} cache An existing cache instance
+   * @returns {void}
+   */
+  constructor(cache) {
+    this._cache = cache || null;
+  }
+
+  /**
+   * Save the compressor's cache to disk.
+   *
+   * @returns {void}
+   */
   saveCache() {
     if (this._cache) {
       this._cache.save();
     }
   }
 
+  /**
+   * Retrieve full source size with optional min+gz sizes attached
+   *
+   * @param   {Object}          opts            Object options
+   * @param   {boolean}         opts.minified   When true, includes minified length
+   * @param   {boolean}         opts.gzip       When true, includes gzipped length
+   * @param   {Object}          opts.uglifyOpts Options to pass to uglify
+   * @param   {Object}          opts.gzipOpts   Options to pass to gzip
+   *
+   * @returns {Promise<Object>} The aggregated code size statistics
+   */
   getSizes(opts) {
     const hashedKey = hash(opts);
 

--- a/lib/utils/compressor.js
+++ b/lib/utils/compressor.js
@@ -1,0 +1,110 @@
+"use strict";
+
+const farmhash = require("farmhash");
+const uglify = require("uglify-js");
+const zlib = require("zlib");
+
+const Cache = require("./cache");
+
+const DEFAULT_UGLIFY_OPTS = {
+  fromString: true,
+  warnings: false,
+  output: {
+    // eslint-disable-next-line camelcase
+    max_line_len: Infinity
+  }
+};
+
+const DEFAULT_GZIP_OPTS = { level: 9 };
+
+const gzip = opts =>
+  new Promise((resolve, reject) =>
+    zlib.gzip(
+      opts.source,
+      opts.gzipOpts || DEFAULT_GZIP_OPTS,
+      (err, buffer) => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve(buffer);
+      }
+    ));
+
+const minify = opts =>
+  Promise.resolve(
+    uglify.minify(opts.source, opts.uglifyOpts || DEFAULT_UGLIFY_OPTS)
+  );
+
+const getGzipLength = opts => gzip(opts).then(buffer => buffer.length);
+
+const getMinifiedLength = opts =>
+  minify(opts).then(result => result.code && result.code.length);
+
+module.exports = class Compressor {
+  constructor(cache) {
+    this._cache = cache || null;
+  }
+
+  static init(opts) {
+    opts = opts || {};
+
+    return Cache.init({
+      scope: opts.scope,
+      cacheDir: opts.cacheDir
+    }).then(cache => new Compressor(cache));
+  }
+
+  saveCache() {
+    if (this._cache) {
+      this._cache.save();
+    }
+  }
+
+  getSizes(opts) {
+    const hashedKey = farmhash.hash64(JSON.stringify(opts));
+
+    if (this._cache) {
+      const cachedValue = this._cache.get(hashedKey);
+      if (cachedValue) {
+        return Promise.resolve(cachedValue);
+      }
+    }
+
+    const sizes = {
+      full: opts.source.length,
+      min: "--",
+      minGz: "--"
+    };
+
+    if (!opts.minified && !opts.gzip) {
+      return Promise.resolve(sizes);
+    }
+
+    if (opts.minified && !opts.gzip) {
+      return getMinifiedLength(opts).then(min =>
+        Object.assign({}, sizes, { min }));
+    }
+
+    return minify(opts)
+      .then(result =>
+        Promise.all([
+          Promise.resolve(result.code.length),
+          getGzipLength(
+            Object.assign({}, opts, {
+              source: result.code
+            })
+          )
+        ]).then(compressedSizes =>
+          Object.assign({}, sizes, {
+            min: compressedSizes[0],
+            minGz: compressedSizes[1]
+          })))
+      .then(fullSizes => {
+        if (this._cache) {
+          this._cache.set(hashedKey, fullSizes);
+          this._cache.save();
+        }
+        return fullSizes;
+      });
+  }
+};

--- a/lib/utils/compressor.js
+++ b/lib/utils/compressor.js
@@ -1,10 +1,10 @@
 "use strict";
 
-const farmhash = require("farmhash");
 const uglify = require("uglify-js");
 const zlib = require("zlib");
 
 const Cache = require("./cache");
+const hash = require("./hash");
 
 const DEFAULT_UGLIFY_OPTS = {
   fromString: true,
@@ -61,7 +61,7 @@ module.exports = class Compressor {
   }
 
   getSizes(opts) {
-    const hashedKey = farmhash.hash64(JSON.stringify(opts));
+    const hashedKey = hash(opts);
 
     if (this._cache) {
       const cachedValue = this._cache.get(hashedKey);

--- a/lib/utils/data.js
+++ b/lib/utils/data.js
@@ -1,14 +1,14 @@
 "use strict";
 
-var _ = require("lodash/fp");
+const _ = require("lodash/fp");
 
 /**
  * Data helpers.
  */
 module.exports = {
   // Sum up meta properties.
-  metaSum: function (props) {
-    return _.reduce(function (m, g) {
+  metaSum(props) {
+    return _.reduce((m, g) => {
       return m + _.get(props)(g.meta || g);
     }, 0); // eslint-disable-line no-magic-numbers
   }

--- a/lib/utils/hash.js
+++ b/lib/utils/hash.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const crypto = require("crypto");
+const tryRequire = require("try-require");
+
+const farmhash = tryRequire("farmhash");
+
+module.exports = function (item) {
+  const hashee = typeof item === "string"
+    ? item : JSON.stringify(item);
+
+  return farmhash
+    ? farmhash.hash64(hashee)
+    : crypto.createHash("sha256")
+       .update(hashee)
+       .digest("hex");
+};

--- a/lib/utils/hash.js
+++ b/lib/utils/hash.js
@@ -1,9 +1,14 @@
 "use strict";
 
 const crypto = require("crypto");
-const tryRequire = require("try-require");
 
-const farmhash = tryRequire("farmhash");
+let farmhash;
+try {
+  // eslint-disable-next-line global-require
+  farmhash = require("farmhash");
+} catch (err) {
+  farmhash = null;
+}
 
 module.exports = function (item) {
   const hashee = typeof item === "string"

--- a/lib/utils/parser.js
+++ b/lib/utils/parser.js
@@ -1,21 +1,21 @@
 "use strict";
 
-var _ = require("lodash/fp");
-var babylon = require("babylon");
-var traverse = require("babel-traverse").default;
-var t = require("babel-types");
+const _ = require("lodash/fp");
+const babylon = require("babylon");
+const traverse = require("babel-traverse").default;
+const t = require("babel-types");
 
-var Code = require("../models/code");
-var moduleTypes = require("../models/module-types");
+const Code = require("../models/code");
+const moduleTypes = require("../models/module-types");
 
 // Extracts the path from this string format:
 // !*** ../foo/awesomez.js ***!
-var extractPath = function (pathInfoComment) {
-  var beginningToken = "!*** ";
-  var endToken = " ***!";
+const extractPath = function (pathInfoComment) {
+  const beginningToken = "!*** ";
+  const endToken = " ***!";
 
-  var beginningIndex = pathInfoComment.indexOf(beginningToken);
-  var endIndex = pathInfoComment.indexOf(endToken);
+  const beginningIndex = pathInfoComment.indexOf(beginningToken);
+  const endIndex = pathInfoComment.indexOf(endToken);
   return pathInfoComment.substring(
     beginningIndex + beginningToken.length,
     endIndex
@@ -31,8 +31,8 @@ var extractPath = function (pathInfoComment) {
 //   \**************************/
 // /***/ function(module, exports, __webpack_require__) {
 // ```
-var getFileName = _.flow(
-  _.find(function (comment) {
+const getFileName = _.flow(
+  _.find((comment) => {
     return comment.value.indexOf("!*** ") !== -1;
   }),
   _.get("value"),
@@ -41,13 +41,13 @@ var getFileName = _.flow(
 
 // TODO: determine if this can be more specific
 // https://github.com/FormidableLabs/inspectpack/issues/25
-var isWebpackFunctionExpression = function (node) {
+const isWebpackFunctionExpression = function (node) {
   return t.isFunctionExpression(node);
 };
 
 // Determine whether this module is code,
 // a single reference, or a multi reference
-var getModuleType = function (node) {
+const getModuleType = function (node) {
   // A straight code reference.
   //
   // ```js
@@ -97,7 +97,7 @@ var getModuleType = function (node) {
 };
 
 // Extract the raw code string of this module.
-var getCode = function (node, moduleType, rawCode) {
+const getCode = function (node, moduleType, rawCode) {
   if (moduleType === moduleTypes.CODE) {
     return rawCode.substring(node.start, node.end);
   }
@@ -106,7 +106,7 @@ var getCode = function (node, moduleType, rawCode) {
 };
 
 // Extract the single numeric ref from this module.
-var getSingleRef = function (node, moduleType) {
+const getSingleRef = function (node, moduleType) {
   if (moduleType === moduleTypes.SINGLE_REF) {
     return parseInt(node.value, 10);
   }
@@ -115,9 +115,9 @@ var getSingleRef = function (node, moduleType) {
 };
 
 // Extract an array of numeric refs from this module.
-var getMultiRefs = function (node, moduleType) {
+const getMultiRefs = function (node, moduleType) {
   if (moduleType === moduleType.MULTI_REF) {
-    return node.elements.map(function (element) {
+    return node.elements.map((element) => {
       return parseInt(element.value, 10);
     });
   }
@@ -126,19 +126,19 @@ var getMultiRefs = function (node, moduleType) {
 };
 
 // Matches: /* 39 */
-var isModuleIdLeadingComment = function (leadingComment) {
+const isModuleIdLeadingComment = function (leadingComment) {
   return /\s[0-9]+\s/g.test(leadingComment.value);
 };
 
 // Matches: /***/
-var hasWebpackAsteriskLeadingComment = _.find(function (leadingComment) {
+const hasWebpackAsteriskLeadingComment = _.find((leadingComment) => {
   return leadingComment.value === "*";
 });
 
-var hasModuleIdLeadingComment = _.find(isModuleIdLeadingComment);
+const hasModuleIdLeadingComment = _.find(isModuleIdLeadingComment);
 
 // Is this actually a webpack module?
-var isWebpackSectionType = function (node) {
+const isWebpackSectionType = function (node) {
   return isWebpackFunctionExpression(node) ||
     t.isNumericLiteral(node) ||
     t.isArrayExpression(node) &&
@@ -146,14 +146,14 @@ var isWebpackSectionType = function (node) {
 };
 
 // Does this array section match the standard webpack module comment template?
-var isWebpackArraySection = function (element) {
+const isWebpackArraySection = function (element) {
   return isWebpackSectionType(element) &&
     hasWebpackAsteriskLeadingComment(element.leadingComments) &&
     hasModuleIdLeadingComment(element.leadingComments);
 };
 
 // Does this object section match the standard webpack module comment template?
-var isWebpackObjectSection = function (property) {
+const isWebpackObjectSection = function (property) {
   return isWebpackSectionType(property.value) &&
     hasWebpackAsteriskLeadingComment(property.value.leadingComments) &&
     t.isNumericLiteral(property.key);
@@ -164,24 +164,24 @@ var isWebpackObjectSection = function (property) {
 //   with module IDs as preceding comments
 // - An object expression ({ 14: function() {} })
 //   with module IDs as keys
-var extractModules = function (modules, rawCode) {
+const extractModules = function (modules, rawCode) {
   return {
-    ArrayExpression: function (path) {
-      var webpackSections = path.node.elements
+    ArrayExpression(path) {
+      const webpackSections = path.node.elements
         .filter(isWebpackArraySection);
 
       if (!webpackSections.length) {
         return;
       }
 
-      webpackSections.forEach(function (element) {
-        var moduleIds = element.leadingComments
+      webpackSections.forEach((element) => {
+        const moduleIds = element.leadingComments
           .filter(isModuleIdLeadingComment);
 
         // If we have extra module IDs above the last module ID comment, we treat
         // the extras as "nothing" references (they add nothing to the bundle).
         if (moduleIds.length > 1) {
-          _.initial(moduleIds).forEach(function (reference) {
+          _.initial(moduleIds).forEach((reference) => {
             modules.push(new Code({
               id: parseInt(reference.value.trim(), 10),
               type: moduleTypes.NOTHING_REF
@@ -189,13 +189,13 @@ var extractModules = function (modules, rawCode) {
           });
         }
 
-        var moduleId = parseInt(_.last(moduleIds).value.trim(), 10);
-        var fileName = getFileName(element.leadingComments);
-        var moduleType = getModuleType(element);
+        const moduleId = parseInt(_.last(moduleIds).value.trim(), 10);
+        const fileName = getFileName(element.leadingComments);
+        const moduleType = getModuleType(element);
 
         modules.push(new Code({
           id: moduleId,
-          fileName: fileName,
+          fileName,
           type: moduleType,
           code: getCode(element, moduleType, rawCode),
           singleRef: getSingleRef(element, moduleType),
@@ -203,7 +203,7 @@ var extractModules = function (modules, rawCode) {
         }));
       });
     },
-    ObjectExpression: function (path) {
+    ObjectExpression(path) {
       if (
         !path.node.properties.length ||
         !path.node.properties.every(isWebpackObjectSection)
@@ -211,13 +211,13 @@ var extractModules = function (modules, rawCode) {
         return;
       }
 
-      path.node.properties.forEach(function (property) {
-        var fileName = getFileName(property.value.leadingComments);
-        var moduleType = getModuleType(property.value);
+      path.node.properties.forEach((property) => {
+        const fileName = getFileName(property.value.leadingComments);
+        const moduleType = getModuleType(property.value);
 
         modules.push(new Code({
           id: parseInt(property.key.value, 10),
-          fileName: fileName,
+          fileName,
           type: getModuleType(property.value),
           code: getCode(property.value, moduleType, rawCode),
           singleRef: getSingleRef(property.value, moduleType),
@@ -235,8 +235,8 @@ var extractModules = function (modules, rawCode) {
  * @returns {Array<Code>} The extracted modules
  */
 module.exports = function (rawCode) {
-  var ast = babylon.parse(rawCode);
-  var modules = [];
+  const ast = babylon.parse(rawCode);
+  const modules = [];
   traverse(ast, extractModules(modules, rawCode));
   return modules;
 };

--- a/lib/utils/parser.js
+++ b/lib/utils/parser.js
@@ -32,7 +32,7 @@ const extractPath = function (pathInfoComment) {
 // /***/ function(module, exports, __webpack_require__) {
 // ```
 const getFileName = _.flow(
-  _.find((comment) => {
+  _.find(comment => {
     return comment.value.indexOf("!*** ") !== -1;
   }),
   _.get("value"),
@@ -86,10 +86,7 @@ const getModuleType = function (node) {
   //   \*******************************/
   // [2612, 505, 506, 508, 509],                              <-- Array
   // ```
-  if (
-    t.isArrayExpression(node) &&
-    node.elements.every(t.isNumericLiteral)
-  ) {
+  if (t.isArrayExpression(node) && node.elements.every(t.isNumericLiteral)) {
     return moduleTypes.MULTI_REF;
   }
 
@@ -117,7 +114,7 @@ const getSingleRef = function (node, moduleType) {
 // Extract an array of numeric refs from this module.
 const getMultiRefs = function (node, moduleType) {
   if (moduleType === moduleType.MULTI_REF) {
-    return node.elements.map((element) => {
+    return node.elements.map(element => {
       return parseInt(element.value, 10);
     });
   }
@@ -131,7 +128,7 @@ const isModuleIdLeadingComment = function (leadingComment) {
 };
 
 // Matches: /***/
-const hasWebpackAsteriskLeadingComment = _.find((leadingComment) => {
+const hasWebpackAsteriskLeadingComment = _.find(leadingComment => {
   return leadingComment.value === "*";
 });
 
@@ -141,8 +138,7 @@ const hasModuleIdLeadingComment = _.find(isModuleIdLeadingComment);
 const isWebpackSectionType = function (node) {
   return isWebpackFunctionExpression(node) ||
     t.isNumericLiteral(node) ||
-    t.isArrayExpression(node) &&
-    node.elements.every(t.isNumericLiteral);
+    t.isArrayExpression(node) && node.elements.every(t.isNumericLiteral);
 };
 
 // Does this array section match the standard webpack module comment template?
@@ -159,71 +155,84 @@ const isWebpackObjectSection = function (property) {
     t.isNumericLiteral(property.key);
 };
 
+const extractFromArrayExpression = function (node, modules, rawCode) {
+  const webpackSections = node.elements.filter(isWebpackArraySection);
+
+  if (!webpackSections.length) {
+    return;
+  }
+
+  webpackSections.forEach(element => {
+    const moduleIds = element.leadingComments.filter(isModuleIdLeadingComment);
+
+    // If we have extra module IDs above the last module ID comment, we treat
+    // the extras as "nothing" references (they add nothing to the bundle).
+    if (moduleIds.length > 1) {
+      _.initial(moduleIds).forEach(reference => {
+        modules.push(
+          new Code({
+            id: parseInt(reference.value.trim(), 10),
+            type: moduleTypes.NOTHING_REF
+          })
+        );
+      });
+    }
+
+    const moduleId = parseInt(_.last(moduleIds).value.trim(), 10);
+    const fileName = getFileName(element.leadingComments);
+    const moduleType = getModuleType(element);
+
+    modules.push(
+      new Code({
+        id: moduleId,
+        fileName,
+        type: moduleType,
+        code: getCode(element, moduleType, rawCode),
+        singleRef: getSingleRef(element, moduleType),
+        multiRefs: getMultiRefs(element, moduleType)
+      })
+    );
+  });
+};
+
+const extractFromObjectExpression = function (node, modules, rawCode) {
+  if (
+    !node.properties.length ||
+    !node.properties.every(isWebpackObjectSection)
+  ) {
+    return;
+  }
+
+  node.properties.forEach(property => {
+    const fileName = getFileName(property.value.leadingComments);
+    const moduleType = getModuleType(property.value);
+
+    modules.push(
+      new Code({
+        id: parseInt(property.key.value, 10),
+        fileName,
+        type: getModuleType(property.value),
+        code: getCode(property.value, moduleType, rawCode),
+        singleRef: getSingleRef(property.value, moduleType),
+        multiRefs: getMultiRefs(property.value, moduleType)
+      })
+    );
+  });
+};
+
 // Webpack outputs two types of bundles:
 // - An array expression of function expressions ([function() {}, function() {}])
 //   with module IDs as preceding comments
 // - An object expression ({ 14: function() {} })
 //   with module IDs as keys
 const extractModules = function (modules, rawCode) {
-  return {
-    ArrayExpression(path) {
-      const webpackSections = path.node.elements
-        .filter(isWebpackArraySection);
+  return node => {
+    if (t.isArrayExpression(node)) {
+      extractFromArrayExpression(node, modules, rawCode);
+    }
 
-      if (!webpackSections.length) {
-        return;
-      }
-
-      webpackSections.forEach((element) => {
-        const moduleIds = element.leadingComments
-          .filter(isModuleIdLeadingComment);
-
-        // If we have extra module IDs above the last module ID comment, we treat
-        // the extras as "nothing" references (they add nothing to the bundle).
-        if (moduleIds.length > 1) {
-          _.initial(moduleIds).forEach((reference) => {
-            modules.push(new Code({
-              id: parseInt(reference.value.trim(), 10),
-              type: moduleTypes.NOTHING_REF
-            }));
-          });
-        }
-
-        const moduleId = parseInt(_.last(moduleIds).value.trim(), 10);
-        const fileName = getFileName(element.leadingComments);
-        const moduleType = getModuleType(element);
-
-        modules.push(new Code({
-          id: moduleId,
-          fileName,
-          type: moduleType,
-          code: getCode(element, moduleType, rawCode),
-          singleRef: getSingleRef(element, moduleType),
-          multiRefs: getMultiRefs(element, moduleType)
-        }));
-      });
-    },
-    ObjectExpression(path) {
-      if (
-        !path.node.properties.length ||
-        !path.node.properties.every(isWebpackObjectSection)
-      ) {
-        return;
-      }
-
-      path.node.properties.forEach((property) => {
-        const fileName = getFileName(property.value.leadingComments);
-        const moduleType = getModuleType(property.value);
-
-        modules.push(new Code({
-          id: parseInt(property.key.value, 10),
-          fileName,
-          type: getModuleType(property.value),
-          code: getCode(property.value, moduleType, rawCode),
-          singleRef: getSingleRef(property.value, moduleType),
-          multiRefs: getMultiRefs(property.value, moduleType)
-        }));
-      });
+    if (t.isObjectExpression(node)) {
+      extractFromObjectExpression(node, modules, rawCode);
     }
   };
 };
@@ -237,6 +246,6 @@ const extractModules = function (modules, rawCode) {
 module.exports = function (rawCode) {
   const ast = babylon.parse(rawCode);
   const modules = [];
-  traverse(ast, extractModules(modules, rawCode));
+  traverse.cheap(ast, extractModules(modules, rawCode));
   return modules;
 };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "mkdirp": "^0.5.1",
     "try-require": "^1.2.1",
     "uglify-js": "^2.6.2",
-    "workerpool": "^2.2.0",
+    "workerpool": "https://github.com/FormidableLabs/workerpool#71d4e17",
     "yargs": "^4.3.1"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,12 +32,14 @@
     "yargs": "^4.3.1"
   },
   "devDependencies": {
+    "babel-eslint": "^7.2.1",
     "chai": "^3.5.0",
-    "eslint": "^2.4.0",
-    "eslint-config-defaults": "^10.0.0-alpha.1",
-    "eslint-plugin-filenames": "^0.2.0",
-    "eslint-plugin-lodash-fp": "^1.3.0",
-    "inspectpack-test-fixtures": "^1.0.0",
-    "mocha": "^3.2.0"
+    "eslint": "^3.18.0",
+    "eslint-config-formidable": "^2.0.1",
+    "eslint-plugin-filenames": "^1.1.0",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-lodash-fp": "^2.1.3",
+    "mocha": "^3.2.0",
+    "inspectpack-test-fixtures": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,12 @@
     "babel-traverse": "^6.7.6",
     "babel-types": "^6.7.2",
     "babylon": "^6.7.0",
+    "bluebird": "^3.5.0",
+    "farmhash": "^1.2.1",
     "lodash": "^4.6.1",
+    "mkdirp": "^0.5.1",
     "uglify-js": "^2.6.2",
+    "workerpool": "^2.2.0",
     "yargs": "^4.3.1"
   },
   "devDependencies": {
@@ -39,7 +43,7 @@
     "eslint-plugin-filenames": "^1.1.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-lodash-fp": "^2.1.3",
-    "mocha": "^3.2.0",
-    "inspectpack-test-fixtures": "^1.0.0"
+    "inspectpack-test-fixtures": "^1.0.0",
+    "mocha": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "bluebird": "^3.5.0",
     "lodash": "^4.6.1",
     "mkdirp": "^0.5.1",
-    "try-require": "^1.2.1",
     "uglify-js": "^2.6.2",
     "workerpool": "https://github.com/FormidableLabs/workerpool#71d4e17",
     "yargs": "^4.3.1"

--- a/package.json
+++ b/package.json
@@ -28,12 +28,15 @@
     "babel-types": "^6.7.2",
     "babylon": "^6.7.0",
     "bluebird": "^3.5.0",
-    "farmhash": "^1.2.1",
     "lodash": "^4.6.1",
     "mkdirp": "^0.5.1",
+    "try-require": "^1.2.1",
     "uglify-js": "^2.6.2",
     "workerpool": "^2.2.0",
     "yargs": "^4.3.1"
+  },
+  "optionalDependencies": {
+    "farmhash": "^1.2.1"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.1",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,14 +1,15 @@
 ---
 extends:
   - "plugin:lodash-fp/recommended"
-  - "defaults/configurations/walmart/es5-test"
-  - "defaults/configurations/walmart/es5-node"
+  - formidable/configurations/es6-test
+  - formidable/configurations/es6-node
 
 plugins:
   - lodash-fp
 
 rules:
-  strict: 0
+  func-style: off
+  arrow-parens: off
   no-magic-numbers: off
   no-unused-expressions: off
   max-nested-callbacks: off

--- a/test/smoke.spec.js
+++ b/test/smoke.spec.js
@@ -1,33 +1,33 @@
 "use strict";
 
-var expect = require("chai").expect;
-var fs = require("fs");
+const expect = require("chai").expect;
+const fs = require("fs");
 
-var duplicates = require("../lib/actions/duplicates");
-var pattern = require("../lib/actions/pattern");
-var parse = require("../lib/actions/parse");
-var files = require("../lib/actions/files");
-var versions = require("../lib/actions/versions");
-var sizes = require("../lib/actions/sizes");
+const duplicates = require("../lib/actions/duplicates");
+const pattern = require("../lib/actions/pattern");
+const parse = require("../lib/actions/parse");
+const files = require("../lib/actions/files");
+const versions = require("../lib/actions/versions");
+const sizes = require("../lib/actions/sizes");
 
-var EXTENDED_TIMEOUT = 15000;
+const EXTENDED_TIMEOUT = 15000;
 
-var basicFixturePath = require.resolve(
+const basicFixturePath = require.resolve(
   "inspectpack-test-fixtures/basic-lodash-object-expression"
 );
-var basicFixture = fs.readFileSync(basicFixturePath, "utf8");
+const basicFixture = fs.readFileSync(basicFixturePath, "utf8");
 
-var badBundleFixtureRoot = require
+const badBundleFixtureRoot = require
   .resolve("inspectpack-test-fixtures")
   .replace("/index.js", "");
 
-var badBundleFixturePath = require.resolve(
+const badBundleFixturePath = require.resolve(
   "inspectpack-test-fixtures/badBundle.js"
 );
 
-var badBundleFixture = fs.readFileSync(badBundleFixturePath, "utf8");
+const badBundleFixture = fs.readFileSync(badBundleFixturePath, "utf8");
 
-var checkForErrors = function (done, assertion) {
+const checkForErrors = function (done, assertion) {
   try {
     assertion();
     done();
@@ -36,7 +36,7 @@ var checkForErrors = function (done, assertion) {
   }
 };
 
-describe("Smoke tests", function () {
+describe("Smoke tests", () => {
   it("analyzes duplicates", function (done) {
     this.timeout(EXTENDED_TIMEOUT);
 
@@ -45,9 +45,9 @@ describe("Smoke tests", function () {
       format: "object",
       minified: false,
       gzip: false
-    }, function (err, result) {
+    }, (err, result) => {
       if (err) { done(err); return; }
-      checkForErrors(done, function () {
+      checkForErrors(done, () => {
         expect(result.meta.numFilesWithDuplicates).to.equal(1);
       });
     });
@@ -62,9 +62,9 @@ describe("Smoke tests", function () {
       format: "object",
       minified: false,
       gzip: false
-    }, function (err, result) {
+    }, (err, result) => {
       if (err) { done(err); return; }
-      checkForErrors(done, function () {
+      checkForErrors(done, () => {
         expect(result.meta.numMatches).to.equal(2);
       });
     });
@@ -76,7 +76,7 @@ describe("Smoke tests", function () {
     parse({
       code: basicFixture,
       parseFns: {
-        TEST_PARSE: function (src) {
+        TEST_PARSE(src) {
           return src.indexOf("oh hai mark") !== -1;
         }
       },
@@ -84,9 +84,9 @@ describe("Smoke tests", function () {
       format: "object",
       minified: false,
       gzip: false
-    }, function (err, result) {
+    }, (err, result) => {
       if (err) { done(err); return; }
-      checkForErrors(done, function () {
+      checkForErrors(done, () => {
         expect(result.meta.numMatches).to.equal(1);
       });
     });
@@ -101,9 +101,10 @@ describe("Smoke tests", function () {
       format: "object",
       minified: false,
       gzip: false
-    }, function (err, result) {
+
+    }, (err, result) => {
       if (err) { done(err); return; }
-      checkForErrors(done, function () {
+      checkForErrors(done, () => {
         expect(result.meta.numMatches).to.equal(5);
       });
     });
@@ -118,9 +119,9 @@ describe("Smoke tests", function () {
       format: "object",
       minified: false,
       gzip: false
-    }, function (err, result) {
+    }, (err, result) => {
       if (err) { done(err); return; }
-      checkForErrors(done, function () {
+      checkForErrors(done, () => {
         expect(result).to.have.property("versions");
       });
     });
@@ -134,9 +135,9 @@ describe("Smoke tests", function () {
       format: "object",
       minified: false,
       gzip: false
-    }, function (err, result) {
+    }, (err, result) => {
       if (err) { done(err); return; }
-      checkForErrors(done, function () {
+      checkForErrors(done, () => {
         expect(result.sizes).to.have.lengthOf(4);
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+"@most/multicast@^1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@most/multicast/-/multicast-1.2.5.tgz#ba5abc997f9a6511094bec117914f4959720a8fb"
+  dependencies:
+    "@most/prelude" "^1.4.0"
+
+"@most/prelude@^1.4.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@most/prelude/-/prelude-1.5.0.tgz#0c8ce09f305039d4055d3deb59c9e44cd337854d"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -43,7 +53,7 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-ansi-escapes@^1.1.0:
+ansi-escapes@^1.0.0, ansi-escapes@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
@@ -55,12 +65,22 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.0.0.tgz#5404e93a544c4fec7f048262977bebfe3155e0c1"
+  dependencies:
+    color-convert "^1.0.0"
+
 anymatch@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
   dependencies:
     arrify "^1.0.0"
     micromatch "^2.1.5"
+
+app-root-path@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
 aproba@^1.0.3:
   version "1.1.1"
@@ -129,6 +149,14 @@ assertion-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
 
+ast-types@0.8.18:
+  version "0.8.18"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.18.tgz#c8b98574898e8914e9d8de74b947564a9fe929af"
+
+ast-types@0.9.4:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.4.tgz#410d1f81890aeb8e0a38621558ba5869ae53c91b"
+
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
@@ -157,7 +185,7 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
+babel-code-frame@6.22.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -210,6 +238,10 @@ babel-types@^6.23.0, babel-types@^6.7.2:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
+babylon@6.15.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
+
 babylon@^6.15.0, babylon@^6.16.1, babylon@^6.7.0:
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
@@ -228,6 +260,17 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+beautify-benchmark@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/beautify-benchmark/-/beautify-benchmark-0.2.4.tgz#3151def14c1a2e0d07ff2e476861c7ed0e1ae39b"
+
+benchmark@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
+  dependencies:
+    lodash "^4.17.4"
+    platform "^1.3.3"
+
 big.js@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
@@ -241,6 +284,10 @@ block-stream@*:
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
   dependencies:
     inherits "~2.0.0"
+
+bluebird@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
 boom@2.x.x:
   version "2.10.1"
@@ -336,7 +383,7 @@ chai@^3.5.0:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
-chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -361,15 +408,30 @@ chokidar@^1.0.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
+ci-info@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.0.0.tgz#dc5285f2b4e251821683681c381c3388f46ec534"
+
 circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
 
-cli-cursor@^1.0.1:
+cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
   dependencies:
     restore-cursor "^1.0.1"
+
+cli-spinners@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cli-width@^2.0.0:
   version "2.1.0"
@@ -403,13 +465,27 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+color-convert@^1.0.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  dependencies:
+    color-name "^1.1.1"
+
+color-name@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.2.tgz#5c8ab72b64bd2215d617ae9559ebb148475cf98d"
+
+colors@>=0.6.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
+
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.0:
+commander@2.9.0, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -453,11 +529,32 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cosmiconfig@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-1.1.0.tgz#0dea0f9804efdfb929fbb1b188e25553ea053d37"
+  dependencies:
+    graceful-fs "^4.1.2"
+    js-yaml "^3.4.3"
+    minimist "^1.2.0"
+    object-assign "^4.0.1"
+    os-homedir "^1.0.1"
+    parse-json "^2.2.0"
+    pinkie-promise "^2.0.0"
+    require-from-string "^1.1.0"
+
 create-eslint-index@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/create-eslint-index/-/create-eslint-index-1.0.0.tgz#d954372d86d5792fcd67e9f2b791b1ab162411bb"
   dependencies:
     lodash.get "^4.3.0"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -485,6 +582,10 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+date-fns@^1.27.2:
+  version "1.28.2"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.2.tgz#19e4192d68875c0bf7c9537e3f296a8ec64853ef"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -567,6 +668,10 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -793,7 +898,7 @@ estraverse@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
 
-esutils@^2.0.2:
+esutils@2.0.2, esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
@@ -807,6 +912,18 @@ event-emitter@~0.3.5:
 events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+
+execa@^0.6.0:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.6.3.tgz#57b69a594f081759c69e5370f0d17b9cb11658fe"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -838,11 +955,17 @@ extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
 
+farmhash@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/farmhash/-/farmhash-1.2.1.tgz#2dbf12604ef5ca1f1420fb6600fccb30d5474dfd"
+  dependencies:
+    nan "^2.4.0"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-figures@^1.3.5:
+figures@^1.3.5, figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   dependencies:
@@ -870,6 +993,10 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
+find-parent-dir@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -885,6 +1012,14 @@ flat-cache@^1.2.1:
     del "^2.0.2"
     graceful-fs "^4.1.2"
     write "^0.2.1"
+
+flow-parser@0.40.0:
+  version "0.40.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.40.0.tgz#b3444742189093323c4319c4fe9d35391f46bcbc"
+  dependencies:
+    ast-types "0.8.18"
+    colors ">=0.6.2"
+    minimist ">=0.2.0"
 
 for-in@^1.0.1:
   version "1.0.2"
@@ -967,6 +1102,14 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
+get-stdin@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
 getpass@^0.1.1:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.6.tgz#283ffd9fc1256840875311c1b60e8c40187110e6"
@@ -997,7 +1140,7 @@ glob@7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
+glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -1095,6 +1238,15 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
+husky@^0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.13.3.tgz#bc2066080badc8b8fe3516e881f5bc68a57052ff"
+  dependencies:
+    chalk "^1.1.3"
+    find-parent-dir "^0.3.0"
+    is-ci "^1.0.9"
+    normalize-path "^1.0.0"
+
 ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
@@ -1106,6 +1258,16 @@ ignore@^3.2.0:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+
+indent-string@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
+  dependencies:
+    repeating "^2.0.0"
+
+indent-string@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.1.0.tgz#08ff4334603388399b329e6b9538dc7a3cf5de7d"
 
 indexof@0.0.1:
   version "0.0.1"
@@ -1194,6 +1356,12 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
+is-ci@^1.0.9:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
+  dependencies:
+    ci-info "^1.0.0"
+
 is-dotfile@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.2.tgz#2c132383f39199f8edc268ca01b9b007d205cc4d"
@@ -1211,6 +1379,12 @@ is-extendable@^0.1.1:
 is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
+
+is-finite@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
+  dependencies:
+    number-is-nan "^1.0.0"
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -1267,6 +1441,10 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
@@ -1276,6 +1454,10 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
   dependencies:
     tryit "^1.0.1"
+
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -1289,6 +1471,10 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
@@ -1298,6 +1484,22 @@ isobject@^2.0.0:
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+
+jest-matcher-utils@^19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-19.0.0.tgz#5ecd9b63565d2b001f61fbf7ec4c7f537964564d"
+  dependencies:
+    chalk "^1.1.3"
+    pretty-format "^19.0.0"
+
+jest-validate@19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-19.0.0.tgz#8c6318a20ecfeaba0ba5378bfbb8277abded4173"
+  dependencies:
+    chalk "^1.1.1"
+    jest-matcher-utils "^19.0.0"
+    leven "^2.0.0"
+    pretty-format "^19.0.0"
 
 jodid25519@^1.0.0:
   version "1.0.2"
@@ -1309,7 +1511,7 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@^3.5.1:
+js-yaml@^3.4.3, js-yaml@^3.5.1:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.2.tgz#02d3e2c0f6beab20248d412c352203827d786721"
   dependencies:
@@ -1375,12 +1577,74 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+leven@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lint-staged@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-3.4.0.tgz#52fa85dfc92bb1c6fe8ad0d0d98ca13924e03e4b"
+  dependencies:
+    app-root-path "^2.0.0"
+    cosmiconfig "^1.1.0"
+    execa "^0.6.0"
+    listr "^0.11.0"
+    minimatch "^3.0.0"
+    npm-which "^3.0.1"
+    staged-git-files "0.0.4"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+
+listr-update-renderer@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz#ca80e1779b4e70266807e8eed1ad6abe398550f9"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz#44dc01bb0c34a03c572154d4d08cde9b1dc5620f"
+  dependencies:
+    chalk "^1.1.3"
+    cli-cursor "^1.0.2"
+    date-fns "^1.27.2"
+    figures "^1.7.0"
+
+listr@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.11.0.tgz#5e778bc23806ac3ab984ed75564458151f39b03e"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    figures "^1.7.0"
+    indent-string "^2.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.2.0"
+    listr-verbose-renderer "^0.4.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    ora "^0.2.3"
+    rxjs "^5.0.0-beta.11"
+    stream-to-observable "^0.1.0"
+    strip-ansi "^3.0.1"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -1498,9 +1762,22 @@ lodash@4.15.0:
   version "4.15.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.15.0.tgz#3162391d8f0140aa22cf8f6b3c34d6b7f63d3aa9"
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  dependencies:
+    chalk "^1.0.0"
+
+log-update@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
+  dependencies:
+    ansi-escapes "^1.0.0"
+    cli-cursor "^1.0.2"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -1511,6 +1788,13 @@ loose-envify@^1.0.0:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+lru-cache@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
+  dependencies:
+    pseudomap "^1.0.1"
+    yallist "^2.0.0"
 
 memory-fs@^0.2.0:
   version "0.2.0"
@@ -1561,7 +1845,7 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.2.0:
+minimist@1.2.0, minimist@>=0.2.0, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -1591,6 +1875,14 @@ moment@^2.18.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
+most@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/most/-/most-1.2.2.tgz#8f12e434ad6195ed2e1efb3ec217e0cbcf3e1de8"
+  dependencies:
+    "@most/multicast" "^1.2.5"
+    "@most/prelude" "^1.4.0"
+    symbol-observable "^1.0.2"
+
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
@@ -1603,7 +1895,7 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
-nan@^2.3.0:
+nan@^2.3.0, nan@^2.4.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.1.tgz#d5b01691253326a97a2bbee9e61c55d8d60351e2"
 
@@ -1669,11 +1961,35 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
+
 normalize-path@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
     remove-trailing-separator "^1.0.1"
+
+npm-path@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.3.tgz#15cff4e1c89a38da77f56f6055b24f975dfb2bbe"
+  dependencies:
+    which "^1.2.10"
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
+
+npm-which@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  dependencies:
+    commander "^2.9.0"
+    npm-path "^2.0.2"
+    which "^1.2.10"
 
 npmlog@^4.0.2:
   version "4.0.2"
@@ -1731,11 +2047,20 @@ optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
+ora@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
+  dependencies:
+    chalk "^1.1.1"
+    cli-cursor "^1.0.2"
+    cli-spinners "^0.1.2"
+    object-assign "^4.0.1"
+
 os-browserify@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.2.1.tgz#63fc4ccee5d2d7763d26bbf8601078e6c2e0044f"
 
-os-homedir@^1.0.0:
+os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
@@ -1755,6 +2080,10 @@ osenv@^0.1.4:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
 pako@~0.2.0:
   version "0.2.9"
@@ -1792,6 +2121,10 @@ path-is-absolute@^1.0.0:
 path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 path-parse@^1.0.5:
   version "1.0.5"
@@ -1839,6 +2172,10 @@ pkg-up@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
+platform@^1.3.3:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.4.tgz#6f0fb17edaaa48f21442b3a975c063130f1c3ebd"
+
 pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
@@ -1850,6 +2187,27 @@ prelude-ls@~1.1.2:
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
+prettier@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-0.22.0.tgz#7b37c4480d0858180407e5a8e13f0f47da7385d2"
+  dependencies:
+    ast-types "0.9.4"
+    babel-code-frame "6.22.0"
+    babylon "6.15.0"
+    chalk "1.1.3"
+    esutils "2.0.2"
+    flow-parser "0.40.0"
+    get-stdin "5.0.1"
+    glob "7.1.1"
+    jest-validate "19.0.0"
+    minimist "1.2.0"
+
+pretty-format@^19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-19.0.0.tgz#56530d32acb98a3fa4851c4e2b9d37b420684c84"
+  dependencies:
+    ansi-styles "^3.0.0"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -1866,6 +2224,10 @@ progress@^1.1.8:
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
+
+pseudomap@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -1976,6 +2338,12 @@ repeat-string@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
+repeating@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
+  dependencies:
+    is-finite "^1.0.0"
+
 req-all@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/req-all/-/req-all-0.1.0.tgz#130051e2ace58a02eacbfc9d448577a736a9273a"
@@ -2010,6 +2378,10 @@ request@^2.81.0:
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+
+require-from-string@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
 
 require-main-filename@^1.0.1:
   version "1.0.1"
@@ -2065,6 +2437,12 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+rxjs@^5.0.0-beta.11:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.3.0.tgz#d88ccbdd46af290cbdb97d5d8055e52453fabe2d"
+  dependencies:
+    symbol-observable "^1.0.1"
+
 safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
@@ -2088,6 +2466,16 @@ setimmediate@^1.0.4:
 sha.js@2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.2.6.tgz#17ddeddc5f722fb66501658895461977867315ba"
+
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
 shelljs@^0.7.5:
   version "0.7.7"
@@ -2158,6 +2546,10 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+staged-git-files@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
+
 stream-browserify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db"
@@ -2174,6 +2566,10 @@ stream-http@^2.3.1:
     readable-stream "^2.1.0"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
+
+stream-to-observable@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -2214,6 +2610,10 @@ strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -2227,6 +2627,10 @@ supports-color@3.1.2, supports-color@^3.1.0:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+
+symbol-observable@^1.0.1, symbol-observable@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 table@^3.7.8:
   version "3.8.3"
@@ -2439,6 +2843,12 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
+which@^1.2.10, which@^1.2.9:
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
+  dependencies:
+    isexe "^2.0.0"
+
 wide-align@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.0.tgz#40edde802a71fea1f070da3e62dcda2e7add96ad"
@@ -2461,6 +2871,10 @@ wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
+workerpool@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-2.2.0.tgz#67e45736f6c19cd41fd15f810c545770cf456f98"
+
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
@@ -2478,6 +2892,10 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
+xpipe@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/xpipe/-/xpipe-1.0.5.tgz#8dd8bf45fc3f7f55f0e054b878f43a62614dafdf"
+
 xtend@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
@@ -2485,6 +2903,10 @@ xtend@^4.0.0:
 y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+
+yallist@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
 yargs-parser@^2.4.1:
   version "2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,13 +12,13 @@ acorn-jsx@^3.0.0:
   dependencies:
     acorn "^3.0.4"
 
-acorn@4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
-
 acorn@^3.0.0, acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+
+acorn@^5.0.1:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
 
 ajv-keywords@^1.0.0:
   version "1.5.1"
@@ -157,13 +157,22 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@^6.22.0:
+babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
     chalk "^1.1.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
+
+babel-eslint@^7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.1.tgz#079422eb73ba811e3ca0865ce87af29327f8c52f"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-traverse "^6.23.1"
+    babel-types "^6.23.0"
+    babylon "^6.16.1"
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -178,7 +187,7 @@ babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-traverse@^6.7.6:
+babel-traverse@^6.23.1, babel-traverse@^6.7.6:
   version "6.23.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.23.1.tgz#d3cb59010ecd06a97d81310065f966b699e14f48"
   dependencies:
@@ -201,7 +210,7 @@ babel-types@^6.23.0, babel-types@^6.7.2:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.15.0, babylon@^6.7.0:
+babylon@^6.15.0, babylon@^6.16.1, babylon@^6.7.0:
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
 
@@ -282,7 +291,7 @@ buffer@^4.9.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-builtin-modules@^1.0.0:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -410,7 +419,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.6:
+concat-stream@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -432,6 +441,10 @@ constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
 
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
+
 core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
@@ -439,6 +452,12 @@ core-js@^2.4.0:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+create-eslint-index@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/create-eslint-index/-/create-eslint-index-1.0.0.tgz#d954372d86d5792fcd67e9f2b791b1ab162411bb"
+  dependencies:
+    lodash.get "^4.3.0"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -525,9 +544,16 @@ diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
 
-doctrine@^1.2.2:
+doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
+doctrine@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
@@ -545,6 +571,12 @@ ecc-jsbn@~0.1.1:
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
+
+enhance-visitors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/enhance-visitors/-/enhance-visitors-1.0.0.tgz#aa945d05da465672a1ebd38fee2ed3da8518e95a"
+  dependencies:
+    lodash "^4.13.1"
 
 enhanced-resolve@~0.9.0:
   version "0.9.1"
@@ -631,38 +663,82 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-config-defaults@^10.0.0-alpha.1:
-  version "10.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-defaults/-/eslint-config-defaults-10.0.0-alpha.1.tgz#16836c2507c1adae169e85902996ab079ece5710"
-
-eslint-plugin-filenames@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-filenames/-/eslint-plugin-filenames-0.2.0.tgz#5651a969c46bfed42e174272ff90659366e2b4a2"
-
-eslint-plugin-lodash-fp@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash-fp/-/eslint-plugin-lodash-fp-1.3.0.tgz#bc674f22abacc616eead1191af9a7a7703d26528"
+eslint-ast-utils@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-ast-utils/-/eslint-ast-utils-1.0.0.tgz#4acb86a0a018de08492f922a05b05928809472f4"
   dependencies:
-    eslint "^2.7.0"
+    lodash.get "^4.4.2"
+
+eslint-config-formidable@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-formidable/-/eslint-config-formidable-2.0.1.tgz#995b8f4a15d80109fbfbe409e537686dfaf41fc2"
+
+eslint-import-resolver-node@^0.2.0:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz#5add8106e8c928db2cba232bcd9efa846e3da16c"
+  dependencies:
+    debug "^2.2.0"
+    object-assign "^4.0.1"
+    resolve "^1.1.6"
+
+eslint-module-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz#a6f8c21d901358759cdc35dbac1982ae1ee58bce"
+  dependencies:
+    debug "2.2.0"
+    pkg-dir "^1.0.0"
+
+eslint-plugin-filenames@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-filenames/-/eslint-plugin-filenames-1.1.0.tgz#bb925218ab25b1aad1c622cfa9cb8f43cc03a4ff"
+  dependencies:
+    lodash.camelcase "4.1.1"
+    lodash.kebabcase "4.0.1"
+    lodash.snakecase "4.0.1"
+
+eslint-plugin-import@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz#72ba306fad305d67c4816348a4699a4229ac8b4e"
+  dependencies:
+    builtin-modules "^1.1.1"
+    contains-path "^0.1.0"
+    debug "^2.2.0"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.2.0"
+    eslint-module-utils "^2.0.0"
+    has "^1.0.1"
+    lodash.cond "^4.3.0"
+    minimatch "^3.0.3"
+    pkg-up "^1.0.0"
+
+eslint-plugin-lodash-fp@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash-fp/-/eslint-plugin-lodash-fp-2.1.3.tgz#ec1d6782abb834415334b97a20b145730a0d0a78"
+  dependencies:
+    create-eslint-index "^1.0.0"
+    enhance-visitors "^1.0.0"
+    eslint-ast-utils "^1.0.0"
     lodash "^4.11.1"
+    req-all "^0.1.0"
 
-eslint@^2.4.0, eslint@^2.7.0:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-2.13.1.tgz#e4cc8fa0f009fb829aaae23855a29360be1f6c11"
+eslint@^3.18.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
   dependencies:
+    babel-code-frame "^6.16.0"
     chalk "^1.1.3"
-    concat-stream "^1.4.6"
+    concat-stream "^1.5.2"
     debug "^2.1.1"
-    doctrine "^1.2.2"
-    es6-map "^0.1.3"
+    doctrine "^2.0.0"
     escope "^3.6.0"
-    espree "^3.1.6"
+    espree "^3.4.0"
+    esquery "^1.0.0"
     estraverse "^4.2.0"
     esutils "^2.0.2"
-    file-entry-cache "^1.1.1"
+    file-entry-cache "^2.0.0"
     glob "^7.0.3"
-    globals "^9.2.0"
-    ignore "^3.1.2"
+    globals "^9.14.0"
+    ignore "^3.2.0"
     imurmurhash "^0.1.4"
     inquirer "^0.12.0"
     is-my-json-valid "^2.10.0"
@@ -672,28 +748,35 @@ eslint@^2.4.0, eslint@^2.7.0:
     levn "^0.3.0"
     lodash "^4.0.0"
     mkdirp "^0.5.0"
-    optionator "^0.8.1"
-    path-is-absolute "^1.0.0"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
     path-is-inside "^1.0.1"
     pluralize "^1.2.1"
     progress "^1.1.8"
     require-uncached "^1.0.2"
-    shelljs "^0.6.0"
-    strip-json-comments "~1.0.1"
+    shelljs "^0.7.5"
+    strip-bom "^3.0.0"
+    strip-json-comments "~2.0.1"
     table "^3.7.8"
     text-table "~0.2.0"
     user-home "^2.0.0"
 
-espree@^3.1.6:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.0.tgz#41656fa5628e042878025ef467e78f125cb86e1d"
+espree@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.1.tgz#28a83ab4aaed71ed8fe0f5efe61b76a05c13c4d2"
   dependencies:
-    acorn "4.0.4"
+    acorn "^5.0.1"
     acorn-jsx "^3.0.0"
 
 esprima@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+
+esquery@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+  dependencies:
+    estraverse "^4.0.0"
 
 esrecurse@^4.1.0:
   version "4.1.0"
@@ -702,7 +785,7 @@ esrecurse@^4.1.0:
     estraverse "~4.1.0"
     object-assign "^4.0.1"
 
-estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.0.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -766,9 +849,9 @@ figures@^1.3.5:
     escape-string-regexp "^1.0.5"
     object-assign "^4.1.0"
 
-file-entry-cache@^1.1.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-1.3.1.tgz#44c61ea607ae4be9c1402f41f44270cbfe334ff8"
+file-entry-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
   dependencies:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
@@ -853,6 +936,10 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
+function-bind@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
+
 gauge@~2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.3.tgz#1c23855f962f17b3ad3d0dc7443f304542edfe09"
@@ -910,7 +997,7 @@ glob@7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.5:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -921,9 +1008,9 @@ glob@^7.0.3, glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.0.0, globals@^9.2.0:
-  version "9.16.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.16.0.tgz#63e903658171ec2d9f51b1d31de5e2b8dc01fb80"
+globals@^9.0.0, globals@^9.14.0:
+  version "9.17.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-9.17.0.tgz#0c0ca696d9b9bb694d2e5470bd37777caad50286"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -973,6 +1060,12 @@ has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
+has@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
+  dependencies:
+    function-bind "^1.0.2"
+
 hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
@@ -1006,7 +1099,7 @@ ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
-ignore@^3.1.2:
+ignore@^3.2.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.6.tgz#26e8da0644be0bb4cb39516f6c79f0e0f4ffe48c"
 
@@ -1066,6 +1159,10 @@ inspectpack-test-fixtures@^1.0.0:
 interpret@^0.6.4:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-0.6.6.tgz#fecd7a18e7ce5ca6abfb953e1f86213a49f1625b"
+
+interpret@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.2.tgz#f4f623f0bb7122f15f5717c8e254b8161b5c5b2d"
 
 invariant@^2.2.0:
   version "2.2.2"
@@ -1331,6 +1428,22 @@ lodash.assign@^4.0.3, lodash.assign@^4.0.6:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
+lodash.camelcase@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.1.1.tgz#065b3ff08f0b7662f389934c46a5504c90e0b2d8"
+  dependencies:
+    lodash.capitalize "^4.0.0"
+    lodash.deburr "^4.0.0"
+    lodash.words "^4.0.0"
+
+lodash.capitalize@^4.0.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz#f826c9b4e2a8511d84e3aca29db05e1a4f3b72a9"
+
+lodash.cond@^4.3.0:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
+
 lodash.create@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
@@ -1338,6 +1451,14 @@ lodash.create@3.1.1:
     lodash._baseassign "^3.0.0"
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
+
+lodash.deburr@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-4.1.0.tgz#ddb1bbb3ef07458c0177ba07de14422cb033ff9b"
+
+lodash.get@^4.3.0, lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"
@@ -1347,6 +1468,13 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.kebabcase@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.0.1.tgz#5e63bc9aa2a5562ff3b97ca7af2f803de1bcb90e"
+  dependencies:
+    lodash.deburr "^4.0.0"
+    lodash.words "^4.0.0"
+
 lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
@@ -1355,11 +1483,22 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
+lodash.snakecase@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.0.1.tgz#bd012e5d2f93f7b58b9303e9a7fbfd5db13d6281"
+  dependencies:
+    lodash.deburr "^4.0.0"
+    lodash.words "^4.0.0"
+
+lodash.words@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.words/-/lodash.words-4.2.0.tgz#5ecfeaf8ecf8acaa8e0c8386295f1993c9cf4036"
+
 lodash@4.15.0:
   version "4.15.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.15.0.tgz#3162391d8f0140aa22cf8f6b3c34d6b7f63d3aa9"
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -1412,7 +1551,7 @@ mime-types@^2.1.12, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.27.0"
 
-minimatch@^3.0.0, minimatch@^3.0.2:
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
@@ -1467,6 +1606,10 @@ mute-stream@0.0.5:
 nan@^2.3.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.1.tgz#d5b01691253326a97a2bbee9e61c55d8d60351e2"
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
 node-libs-browser@^0.7.0:
   version "0.7.0"
@@ -1577,7 +1720,7 @@ optimist@~0.6.0:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.1:
+optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -1650,6 +1793,10 @@ path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -1679,6 +1826,18 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  dependencies:
+    find-up "^1.0.0"
+
+pkg-up@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-1.0.0.tgz#3e08fb461525c4421624a33b9f7e6d0af5b05a26"
+  dependencies:
+    find-up "^1.0.0"
 
 pluralize@^1.2.1:
   version "1.2.1"
@@ -1788,6 +1947,12 @@ readline2@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  dependencies:
+    resolve "^1.1.6"
+
 regenerator-runtime@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz#8c4367a904b51ea62a908ac310bf99ff90a82a3e"
@@ -1810,6 +1975,10 @@ repeat-element@^1.1.2:
 repeat-string@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+
+req-all@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/req-all/-/req-all-0.1.0.tgz#130051e2ace58a02eacbfc9d448577a736a9273a"
 
 request@^2.81.0:
   version "2.81.0"
@@ -1856,6 +2025,12 @@ require-uncached@^1.0.2:
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+
+resolve@^1.1.6:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
+  dependencies:
+    path-parse "^1.0.5"
 
 restore-cursor@^1.0.1:
   version "1.0.1"
@@ -1914,9 +2089,13 @@ sha.js@2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.2.6.tgz#17ddeddc5f722fb66501658895461977867315ba"
 
-shelljs@^0.6.0:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.6.1.tgz#ec6211bed1920442088fe0f70b2837232ed2c8a8"
+shelljs@^0.7.5:
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.7.tgz#b2f5c77ef97148f4b4f6e22682e10bba8667cff1"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 signal-exit@^3.0.0:
   version "3.0.2"
@@ -2031,9 +2210,9 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
-strip-json-comments@~1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -2150,8 +2329,8 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 uglify-js@^2.6.2:
-  version "2.8.16"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.16.tgz#d286190b6eefc6fd65eb0ecac6551e0b0e8839a4"
+  version "2.8.21"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.21.tgz#1733f669ae6f82fc90c7b25ec0f5c783ee375314"
   dependencies:
     source-map "~0.5.1"
     yargs "~3.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,16 +2,6 @@
 # yarn lockfile v1
 
 
-"@most/multicast@^1.2.5":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@most/multicast/-/multicast-1.2.5.tgz#ba5abc997f9a6511094bec117914f4959720a8fb"
-  dependencies:
-    "@most/prelude" "^1.4.0"
-
-"@most/prelude@^1.4.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@most/prelude/-/prelude-1.5.0.tgz#0c8ce09f305039d4055d3deb59c9e44cd337854d"
-
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -53,7 +43,7 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-ansi-escapes@^1.0.0, ansi-escapes@^1.1.0:
+ansi-escapes@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
@@ -65,22 +55,12 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.0.0.tgz#5404e93a544c4fec7f048262977bebfe3155e0c1"
-  dependencies:
-    color-convert "^1.0.0"
-
 anymatch@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
   dependencies:
     arrify "^1.0.0"
     micromatch "^2.1.5"
-
-app-root-path@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
 aproba@^1.0.3:
   version "1.1.1"
@@ -149,14 +129,6 @@ assertion-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
 
-ast-types@0.8.18:
-  version "0.8.18"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.18.tgz#c8b98574898e8914e9d8de74b947564a9fe929af"
-
-ast-types@0.9.4:
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.4.tgz#410d1f81890aeb8e0a38621558ba5869ae53c91b"
-
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
@@ -185,7 +157,7 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@6.22.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
+babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -238,10 +210,6 @@ babel-types@^6.23.0, babel-types@^6.7.2:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@6.15.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
-
 babylon@^6.15.0, babylon@^6.16.1, babylon@^6.7.0:
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
@@ -259,17 +227,6 @@ bcrypt-pbkdf@^1.0.0:
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
   dependencies:
     tweetnacl "^0.14.3"
-
-beautify-benchmark@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/beautify-benchmark/-/beautify-benchmark-0.2.4.tgz#3151def14c1a2e0d07ff2e476861c7ed0e1ae39b"
-
-benchmark@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
-  dependencies:
-    lodash "^4.17.4"
-    platform "^1.3.3"
 
 big.js@^3.1.3:
   version "3.1.3"
@@ -383,7 +340,7 @@ chai@^3.5.0:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
-chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -408,30 +365,15 @@ chokidar@^1.0.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
-ci-info@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.0.0.tgz#dc5285f2b4e251821683681c381c3388f46ec534"
-
 circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
 
-cli-cursor@^1.0.1, cli-cursor@^1.0.2:
+cli-cursor@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
   dependencies:
     restore-cursor "^1.0.1"
-
-cli-spinners@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
-
-cli-truncate@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
-  dependencies:
-    slice-ansi "0.0.4"
-    string-width "^1.0.1"
 
 cli-width@^2.0.0:
   version "2.1.0"
@@ -465,27 +407,13 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-color-convert@^1.0.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
-  dependencies:
-    color-name "^1.1.1"
-
-color-name@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.2.tgz#5c8ab72b64bd2215d617ae9559ebb148475cf98d"
-
-colors@>=0.6.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
-
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.0, commander@^2.9.0:
+commander@2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -529,32 +457,11 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cosmiconfig@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-1.1.0.tgz#0dea0f9804efdfb929fbb1b188e25553ea053d37"
-  dependencies:
-    graceful-fs "^4.1.2"
-    js-yaml "^3.4.3"
-    minimist "^1.2.0"
-    object-assign "^4.0.1"
-    os-homedir "^1.0.1"
-    parse-json "^2.2.0"
-    pinkie-promise "^2.0.0"
-    require-from-string "^1.1.0"
-
 create-eslint-index@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/create-eslint-index/-/create-eslint-index-1.0.0.tgz#d954372d86d5792fcd67e9f2b791b1ab162411bb"
   dependencies:
     lodash.get "^4.3.0"
-
-cross-spawn@^5.0.1:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
-  dependencies:
-    lru-cache "^4.0.1"
-    shebang-command "^1.2.0"
-    which "^1.2.9"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -582,10 +489,6 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
-
-date-fns@^1.27.2:
-  version "1.28.2"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.2.tgz#19e4192d68875c0bf7c9537e3f296a8ec64853ef"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -668,10 +571,6 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
-
-elegant-spinner@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -898,7 +797,7 @@ estraverse@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
 
-esutils@2.0.2, esutils@^2.0.2:
+esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
@@ -912,18 +811,6 @@ event-emitter@~0.3.5:
 events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
-
-execa@^0.6.0:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.6.3.tgz#57b69a594f081759c69e5370f0d17b9cb11658fe"
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -965,7 +852,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-figures@^1.3.5, figures@^1.7.0:
+figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   dependencies:
@@ -993,10 +880,6 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
-find-parent-dir@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
-
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -1012,14 +895,6 @@ flat-cache@^1.2.1:
     del "^2.0.2"
     graceful-fs "^4.1.2"
     write "^0.2.1"
-
-flow-parser@0.40.0:
-  version "0.40.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.40.0.tgz#b3444742189093323c4319c4fe9d35391f46bcbc"
-  dependencies:
-    ast-types "0.8.18"
-    colors ">=0.6.2"
-    minimist ">=0.2.0"
 
 for-in@^1.0.1:
   version "1.0.2"
@@ -1102,14 +977,6 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
-get-stdin@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
-
-get-stream@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
-
 getpass@^0.1.1:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.6.tgz#283ffd9fc1256840875311c1b60e8c40187110e6"
@@ -1140,7 +1007,7 @@ glob@7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -1238,15 +1105,6 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
-husky@^0.13.3:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-0.13.3.tgz#bc2066080badc8b8fe3516e881f5bc68a57052ff"
-  dependencies:
-    chalk "^1.1.3"
-    find-parent-dir "^0.3.0"
-    is-ci "^1.0.9"
-    normalize-path "^1.0.0"
-
 ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
@@ -1258,16 +1116,6 @@ ignore@^3.2.0:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
-
-indent-string@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
-  dependencies:
-    repeating "^2.0.0"
-
-indent-string@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.1.0.tgz#08ff4334603388399b329e6b9538dc7a3cf5de7d"
 
 indexof@0.0.1:
   version "0.0.1"
@@ -1356,12 +1204,6 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-ci@^1.0.9:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
-  dependencies:
-    ci-info "^1.0.0"
-
 is-dotfile@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.2.tgz#2c132383f39199f8edc268ca01b9b007d205cc4d"
@@ -1379,12 +1221,6 @@ is-extendable@^0.1.1:
 is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
-
-is-finite@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
-  dependencies:
-    number-is-nan "^1.0.0"
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -1441,10 +1277,6 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
-is-promise@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
-
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
@@ -1454,10 +1286,6 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
   dependencies:
     tryit "^1.0.1"
-
-is-stream@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -1471,10 +1299,6 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
-isexe@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
@@ -1484,22 +1308,6 @@ isobject@^2.0.0:
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
-
-jest-matcher-utils@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-19.0.0.tgz#5ecd9b63565d2b001f61fbf7ec4c7f537964564d"
-  dependencies:
-    chalk "^1.1.3"
-    pretty-format "^19.0.0"
-
-jest-validate@19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-19.0.0.tgz#8c6318a20ecfeaba0ba5378bfbb8277abded4173"
-  dependencies:
-    chalk "^1.1.1"
-    jest-matcher-utils "^19.0.0"
-    leven "^2.0.0"
-    pretty-format "^19.0.0"
 
 jodid25519@^1.0.0:
   version "1.0.2"
@@ -1511,7 +1319,7 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@^3.4.3, js-yaml@^3.5.1:
+js-yaml@^3.5.1:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.2.tgz#02d3e2c0f6beab20248d412c352203827d786721"
   dependencies:
@@ -1577,74 +1385,12 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-leven@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
-
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
-
-lint-staged@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-3.4.0.tgz#52fa85dfc92bb1c6fe8ad0d0d98ca13924e03e4b"
-  dependencies:
-    app-root-path "^2.0.0"
-    cosmiconfig "^1.1.0"
-    execa "^0.6.0"
-    listr "^0.11.0"
-    minimatch "^3.0.0"
-    npm-which "^3.0.1"
-    staged-git-files "0.0.4"
-
-listr-silent-renderer@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
-
-listr-update-renderer@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz#ca80e1779b4e70266807e8eed1ad6abe398550f9"
-  dependencies:
-    chalk "^1.1.3"
-    cli-truncate "^0.2.1"
-    elegant-spinner "^1.0.1"
-    figures "^1.7.0"
-    indent-string "^3.0.0"
-    log-symbols "^1.0.2"
-    log-update "^1.0.2"
-    strip-ansi "^3.0.1"
-
-listr-verbose-renderer@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz#44dc01bb0c34a03c572154d4d08cde9b1dc5620f"
-  dependencies:
-    chalk "^1.1.3"
-    cli-cursor "^1.0.2"
-    date-fns "^1.27.2"
-    figures "^1.7.0"
-
-listr@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/listr/-/listr-0.11.0.tgz#5e778bc23806ac3ab984ed75564458151f39b03e"
-  dependencies:
-    chalk "^1.1.3"
-    cli-truncate "^0.2.1"
-    figures "^1.7.0"
-    indent-string "^2.1.0"
-    is-promise "^2.1.0"
-    is-stream "^1.1.0"
-    listr-silent-renderer "^1.1.1"
-    listr-update-renderer "^0.2.0"
-    listr-verbose-renderer "^0.4.0"
-    log-symbols "^1.0.2"
-    log-update "^1.0.2"
-    ora "^0.2.3"
-    rxjs "^5.0.0-beta.11"
-    stream-to-observable "^0.1.0"
-    strip-ansi "^3.0.1"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -1762,22 +1508,9 @@ lodash@4.15.0:
   version "4.15.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.15.0.tgz#3162391d8f0140aa22cf8f6b3c34d6b7f63d3aa9"
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-log-symbols@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
-  dependencies:
-    chalk "^1.0.0"
-
-log-update@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
-  dependencies:
-    ansi-escapes "^1.0.0"
-    cli-cursor "^1.0.2"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -1788,13 +1521,6 @@ loose-envify@^1.0.0:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
-
-lru-cache@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
-  dependencies:
-    pseudomap "^1.0.1"
-    yallist "^2.0.0"
 
 memory-fs@^0.2.0:
   version "0.2.0"
@@ -1845,7 +1571,7 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@1.2.0, minimist@>=0.2.0, minimist@^1.2.0:
+minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -1874,14 +1600,6 @@ mocha@^3.2.0:
 moment@^2.18.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
-
-most@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/most/-/most-1.2.2.tgz#8f12e434ad6195ed2e1efb3ec217e0cbcf3e1de8"
-  dependencies:
-    "@most/multicast" "^1.2.5"
-    "@most/prelude" "^1.4.0"
-    symbol-observable "^1.0.2"
 
 ms@0.7.1:
   version "0.7.1"
@@ -1961,35 +1679,11 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
-
 normalize-path@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
     remove-trailing-separator "^1.0.1"
-
-npm-path@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.3.tgz#15cff4e1c89a38da77f56f6055b24f975dfb2bbe"
-  dependencies:
-    which "^1.2.10"
-
-npm-run-path@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
-  dependencies:
-    path-key "^2.0.0"
-
-npm-which@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
-  dependencies:
-    commander "^2.9.0"
-    npm-path "^2.0.2"
-    which "^1.2.10"
 
 npmlog@^4.0.2:
   version "4.0.2"
@@ -2047,20 +1741,11 @@ optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
-ora@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
-  dependencies:
-    chalk "^1.1.1"
-    cli-cursor "^1.0.2"
-    cli-spinners "^0.1.2"
-    object-assign "^4.0.1"
-
 os-browserify@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.2.1.tgz#63fc4ccee5d2d7763d26bbf8601078e6c2e0044f"
 
-os-homedir@^1.0.0, os-homedir@^1.0.1:
+os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
@@ -2080,10 +1765,6 @@ osenv@^0.1.4:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
-
-p-finally@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
 pako@~0.2.0:
   version "0.2.9"
@@ -2121,10 +1802,6 @@ path-is-absolute@^1.0.0:
 path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
-
-path-key@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 path-parse@^1.0.5:
   version "1.0.5"
@@ -2172,10 +1849,6 @@ pkg-up@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
-platform@^1.3.3:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.4.tgz#6f0fb17edaaa48f21442b3a975c063130f1c3ebd"
-
 pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
@@ -2187,27 +1860,6 @@ prelude-ls@~1.1.2:
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
-
-prettier@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-0.22.0.tgz#7b37c4480d0858180407e5a8e13f0f47da7385d2"
-  dependencies:
-    ast-types "0.9.4"
-    babel-code-frame "6.22.0"
-    babylon "6.15.0"
-    chalk "1.1.3"
-    esutils "2.0.2"
-    flow-parser "0.40.0"
-    get-stdin "5.0.1"
-    glob "7.1.1"
-    jest-validate "19.0.0"
-    minimist "1.2.0"
-
-pretty-format@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-19.0.0.tgz#56530d32acb98a3fa4851c4e2b9d37b420684c84"
-  dependencies:
-    ansi-styles "^3.0.0"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -2224,10 +1876,6 @@ progress@^1.1.8:
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
-
-pseudomap@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -2338,12 +1986,6 @@ repeat-string@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
-repeating@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
-  dependencies:
-    is-finite "^1.0.0"
-
 req-all@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/req-all/-/req-all-0.1.0.tgz#130051e2ace58a02eacbfc9d448577a736a9273a"
@@ -2378,10 +2020,6 @@ request@^2.81.0:
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
-
-require-from-string@^1.1.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
 
 require-main-filename@^1.0.1:
   version "1.0.1"
@@ -2437,12 +2075,6 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
-rxjs@^5.0.0-beta.11:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.3.0.tgz#d88ccbdd46af290cbdb97d5d8055e52453fabe2d"
-  dependencies:
-    symbol-observable "^1.0.1"
-
 safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
@@ -2466,16 +2098,6 @@ setimmediate@^1.0.4:
 sha.js@2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.2.6.tgz#17ddeddc5f722fb66501658895461977867315ba"
-
-shebang-command@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
-  dependencies:
-    shebang-regex "^1.0.0"
-
-shebang-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
 shelljs@^0.7.5:
   version "0.7.7"
@@ -2546,10 +2168,6 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-staged-git-files@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
-
 stream-browserify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db"
@@ -2566,10 +2184,6 @@ stream-http@^2.3.1:
     readable-stream "^2.1.0"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
-
-stream-to-observable@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -2610,10 +2224,6 @@ strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
-strip-eof@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
-
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -2627,10 +2237,6 @@ supports-color@3.1.2, supports-color@^3.1.0:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-
-symbol-observable@^1.0.1, symbol-observable@^1.0.2:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 table@^3.7.8:
   version "3.8.3"
@@ -2695,6 +2301,10 @@ tough-cookie@~2.3.0:
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
     punycode "^1.4.1"
+
+try-require@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/try-require/-/try-require-1.2.1.tgz#34489a2cac0c09c1cc10ed91ba011594d4333be2"
 
 tryit@^1.0.1:
   version "1.0.3"
@@ -2843,12 +2453,6 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@^1.2.10, which@^1.2.9:
-  version "1.2.14"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
-  dependencies:
-    isexe "^2.0.0"
-
 wide-align@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.0.tgz#40edde802a71fea1f070da3e62dcda2e7add96ad"
@@ -2892,10 +2496,6 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-xpipe@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/xpipe/-/xpipe-1.0.5.tgz#8dd8bf45fc3f7f55f0e054b878f43a62614dafdf"
-
 xtend@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
@@ -2903,10 +2503,6 @@ xtend@^4.0.0:
 y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
-
-yallist@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
 yargs-parser@^2.4.1:
   version "2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1702,7 +1702,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -2475,9 +2475,11 @@ wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
-workerpool@^2.2.0:
+"workerpool@https://github.com/FormidableLabs/workerpool#71d4e17":
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-2.2.0.tgz#67e45736f6c19cd41fd15f810c545770cf456f98"
+  resolved "https://github.com/FormidableLabs/workerpool#71d4e17"
+  dependencies:
+    object-assign "^4.1.1"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Depends on https://github.com/FormidableLabs/inspectpack/pull/26

This PR introduces a child process daemon mode for interactive usage (e.g. `webpack-dashboard`). Creating a daemon prevents `inspectpack` from blocking UI interactions and allows for future parallelization of action runners.

## Performance improvements:
- Use `traverse.cheap` in the parser
- Remove all `gzipSync` in the `sizes` action for both daemon and CLI mode
- Add both an action-level and module-level in-memory + disk cache, making all builds except the first run cheaper

## Other improvements:
- Centralize file size gathering/caching into an injectable Compressor class

Todo:

- [x] PR/Fork `workerpool` to allow for worker args and inspector support (will fix compressor cache's support for custom `cacheDir`s)
- [x] Useful comments