### PR TITLE
Integrate puglify as an optional dependency

### DIFF
--- a/lib/utils/compressor.js
+++ b/lib/utils/compressor.js
@@ -6,8 +6,15 @@ const zlib = require("zlib");
 const Cache = require("./cache");
 const hash = require("./hash");
 
+let Puglifier;
+try {
+  // eslint-disable-next-line global-require
+  Puglifier = require("puglify");
+} catch (err) {
+  Puglifier = null;
+}
+
 const DEFAULT_UGLIFY_OPTS = {
-  fromString: true,
   warnings: false,
   output: {
     // eslint-disable-next-line camelcase
@@ -30,10 +37,20 @@ const gzip = opts =>
       }
     ));
 
-const minify = opts =>
-  Promise.resolve(
-    uglify.minify(opts.source, opts.uglifyOpts || DEFAULT_UGLIFY_OPTS)
-  );
+const minify = (opts, puglifier) =>
+  puglifier
+    ? puglifier.puglify({
+      code: opts.source,
+      opts: opts.uglifyOpts || DEFAULT_UGLIFY_OPTS
+    })
+    : Promise.resolve(
+      uglify.minify(
+        opts.source,
+        Object.assign({}, opts.uglifyOpts || DEFAULT_UGLIFY_OPTS, {
+          fromString: true
+        })
+      )
+    );
 
 const getGzipLength = opts => gzip(opts).then(buffer => buffer.length);
 
@@ -54,17 +71,24 @@ module.exports = class Compressor {
     return Cache.init({
       scope: opts.scope,
       cacheDir: opts.cacheDir
-    }).then(cache => new Compressor(cache));
+    }).then(cache => new Compressor({ cache }));
   }
 
   /**
    * A centralized manager for uglifying, gzipping, and retrieving file sizes.
    *
-   * @param   {Cache} cache An existing cache instance
+   * @param   {Object}    opts Compressor options
+   * @param   {Cache}     opts.cache      An existing cache instance
+   * @param   {Puglifier} opts.puglifier  A puglifier instance to use
+   * @param   {boolean}   opts.usePuglify When true, uses `puglify` to paralellize
    * @returns {void}
    */
-  constructor(cache) {
-    this._cache = cache || null;
+  constructor(opts) {
+    opts = opts || { usePuglify: true };
+    this._cache = opts.cache || null;
+    if (Puglifier && opts.usePuglify) {
+      this.puglifier = opts.puglifier || new Puglifier();
+    }
   }
 
   /**
@@ -114,7 +138,7 @@ module.exports = class Compressor {
         Object.assign({}, sizes, { min }));
     }
 
-    return minify(opts)
+    return minify(opts, this.puglifier)
       .then(result =>
         Promise.all([
           Promise.resolve(result.code.length),
@@ -135,5 +159,11 @@ module.exports = class Compressor {
         }
         return fullSizes;
       });
+  }
+
+  destroy() {
+    if (this.puglifier) {
+      this.puglifier.terminate();
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "yargs": "^4.3.1"
   },
   "optionalDependencies": {
-    "farmhash": "^1.2.1"
+    "farmhash": "^1.2.1",
+    "puglify": "^0.2.2"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,15 @@
 # yarn lockfile v1
 
 
+"@tptee/webworker-threads@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@tptee/webworker-threads/-/webworker-threads-0.8.0.tgz#cc4b09be75a656d1ea0da29707b2c7cf5b122d24"
+  dependencies:
+    bindings "^1.2.1"
+    nan "^2.4.0"
+    node-pre-gyp "^0.6.33"
+    node-pre-gyp-github "^1.3.1"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -255,6 +264,10 @@ binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
 
+bindings@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.2.1.tgz#14ad6113812d2d37d72e67b4cacb4bb726505f11"
+
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -481,7 +494,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.0:
+commander@2.9.0, commander@^2.9.0, commander@~2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -1115,6 +1128,12 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+github@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/github/-/github-0.2.4.tgz#24fa7f0e13fa11b946af91134c51982a91ce538b"
+  dependencies:
+    mime "^1.2.11"
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
@@ -1701,6 +1720,10 @@ mime-types@^2.1.12, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.27.0"
 
+mime@^1.2.11:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
+
 minimalistic-assert@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz#702be2dda6b37f4836bcb3f5db56641b64a1d3d3"
@@ -1797,7 +1820,14 @@ node-libs-browser@^2.0.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
-node-pre-gyp@^0.6.29:
+node-pre-gyp-github@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp-github/-/node-pre-gyp-github-1.3.1.tgz#c6965303995b5b083eca64a1aa35fd2b511dcbb3"
+  dependencies:
+    commander "^2.9.0"
+    github "^0.2.4"
+
+node-pre-gyp@^0.6.29, node-pre-gyp@^0.6.33:
   version "0.6.34"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.34.tgz#94ad1c798a11d7fc67381b50d47f8cc18d9799f7"
   dependencies:
@@ -2049,6 +2079,14 @@ public-encrypt@^4.0.0:
     create-hash "^1.1.0"
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
+
+puglify@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/puglify/-/puglify-0.2.2.tgz#218029883f0e892bef5c8cdc6daf7b36d0d17dce"
+  dependencies:
+    "@tptee/webworker-threads" "^0.8.0"
+    uglify-js "https://github.com/mishoo/UglifyJS2#bbb5f2a89c9b68b35aec96ccc48a9d0ef250780a"
+    uuid "^3.0.1"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -2526,6 +2564,15 @@ uglify-js@^2.6.2, uglify-js@^2.8.5:
   optionalDependencies:
     uglify-to-browserify "~1.0.0"
 
+"uglify-js@https://github.com/mishoo/UglifyJS2#bbb5f2a89c9b68b35aec96ccc48a9d0ef250780a":
+  version "2.8.22"
+  resolved "https://github.com/mishoo/UglifyJS2#bbb5f2a89c9b68b35aec96ccc48a9d0ef250780a"
+  dependencies:
+    commander "~2.9.0"
+    source-map "~0.5.1"
+  optionalDependencies:
+    uglify-to-browserify "~1.0.0"
+
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
@@ -2557,7 +2604,7 @@ util@0.10.3, util@^0.10.3:
   dependencies:
     inherits "2.0.1"
 
-uuid@^3.0.0:
+uuid@^3.0.0, uuid@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 


### PR DESCRIPTION
`puglify` gives a modest speedup to the `sizes` and `duplicates` actions. In particular, `sizes` time shrunk to ~9s, an improvement over the previous range of 12.5-14.3s. It's likely faster than the new benchmarks indicate because there's not a good way to benchmark "hot" and "cold" startup in `benchmark.js`. I haven't benchmarked this finding, but rebuilds in `webpack-dashboard` seem snappier after integrating `puglify`.

All of `puglify`'s native dependencies have binaries, and if they fail, `inspectpack` falls back to pure `uglify`.

I think we can squeeze out even better perf in the future by:
- batching `getSizes` calls to lower serialization overhead and to allow threads to consume more jobs at once
- adding a stream interface to actions so we can emit module sizes before tackling the full bundle size (full bundle minification is the big bottleneck for `webpack-dashboard` right now, since it currently blocks display of the modules pane)