### PR TITLE
Fix size inspection of bundles created with devtool: eval

### DIFF
--- a/lib/utils/code.js
+++ b/lib/utils/code.js
@@ -15,8 +15,9 @@ module.exports = {
    * },
    * ```
    *
-   * Which parsers like Uglify and Babylon don't like. We add a prefix and
-   * truncate the trailing comma to produce:
+   * Which parsers like Uglify and Babylon don't like. We add a prefix,
+   * truncate the trailing comma, and ensure the closing bracket is on
+   * a new line to produce:
    *
    * ```js
    * a=function(module, exports, __webpack_require__) {
@@ -28,6 +29,6 @@ module.exports = {
    * @returns {String}   Parseable code
    */
   toParseable(src) {
-    return `a=${src.trim().replace(/,$/, "")}`;
+    return `a=${src.trim().replace(/},?$/, "\n}")}`;
   }
 };


### PR DESCRIPTION
Addresses #34. 

When parsing bundles created with the devtool option set to `eval` a `//` comment proceeds the closing `}` of each module function which results in uglify parse errors. This fix ensures the closing bracket is on a new line.  Tested with all [devtool](https://webpack.js.org/configuration/devtool/#devtool) options listed 

/cc @ryan-roemer 