### PR TITLE
Make code more resilient to unexpected inputs + moar tests.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,13 @@
 History
 =======
 
+## Unreleased
+
+* Improve module ID comment inference logic.
+* Add `--allow-empty` command flag and internal option for malformed bundles.
+* Capture bundle validation errors in callback rather than throwing
+  synchronously.
+
 ## 1.2.1
 
 * Fix size inspection of bundles created with `devtool: eval`. (*[@kkerr1][]*)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Options:
   --minified, -m      Calculate / display minified byte sizes              [boolean] [default: true]
   --gzip, -g          Calculate / display minified + gzipped byte size (implies `--minified`)
                                                                            [boolean] [default: true]
+  --allow-empty       Allow unparseable / empty bundles                   [boolean] [default: false]
   --pattern, -p       Regular expression string(s) to match on                 [array] [default: []]
   --path              Path to input file(s)                                    [array] [default: []]
   --suspect-patterns  Known 'suspicious' patterns for `--action=pattern`                   [boolean]

--- a/lib/args.js
+++ b/lib/args.js
@@ -135,6 +135,11 @@ module.exports = {
         type: "boolean",
         default: true
       })
+      .option("allow-empty", {
+        describe: "Allow unparseable / empty bundles",
+        type: "boolean",
+        default: false
+      })
       .option("pattern", {
         alias: "p",
         describe: "Regular expression string(s) to match on",

--- a/lib/models/bundle.js
+++ b/lib/models/bundle.js
@@ -265,16 +265,20 @@ Bundle.create = function (opts, callback) {
         code: opts.code
       });
 
-      bundle.validate();
+      let err = null;
+      try {
+        bundle.validate();
+      } catch (validateErr) {
+        err = validateErr;
+      }
 
-      callback(null, bundle);
+      callback(err, bundle);
     });
   }
 
-  return fs.readFile(opts.bundle, (err, data) => {
-    if (err) {
-      callback(err);
-      return;
+  return fs.readFile(opts.bundle, (readErr, data) => {
+    if (readErr) {
+      return void callback(readErr);
     }
 
     // Create and validate.
@@ -283,8 +287,13 @@ Bundle.create = function (opts, callback) {
       code: data.toString()
     });
 
-    bundle.validate();
+    let err = null;
+    try {
+      bundle.validate();
+    } catch (validateErr) {
+      err = validateErr;
+    }
 
-    callback(null, bundle);
+    callback(err, bundle);
   });
 };

--- a/lib/models/bundle.js
+++ b/lib/models/bundle.js
@@ -11,13 +11,15 @@ const parse = require("../parser");
  * - `codes`: Array of code objects by Webpack ID.
  * - `groups`: Object of code objects grouped by `baseName`.
  *
- * @param {Object}    opts      Options
- * @param {String}    opts.code Raw JavaScript code
+ * @param {Object}    opts            Options
+ * @param {String}    opts.code       Raw JavaScript code
+ * @param {Boolean}   opts.allowEmpty Allow empty/unparseable bundles
  * @returns {void}
  */
 const Bundle = module.exports = function Bundle(opts) {
   this.path = opts.path;
   this.code = opts.code;
+  this.allowEmpty = opts.allowEmpty;
   this.codes = parse(opts.code).filter((code) => {
     return !code.isNothingRef() && !code.isUnknown();
   });
@@ -39,7 +41,7 @@ const Bundle = module.exports = function Bundle(opts) {
 Bundle.prototype.validate = function () {
   const codes = this.codes;
 
-  if (codes.length === 0) {
+  if (!this.allowEmpty && codes.length === 0) {
     throw new Error("No code sections found");
   }
 
@@ -262,7 +264,8 @@ Bundle.create = function (opts, callback) {
     // Prevent Zalgo by executing on the next tick.
     return setImmediate(() => {
       const bundle = new Bundle({
-        code: opts.code
+        code: opts.code,
+        allowEmpty: opts.allowEmpty
       });
 
       let err = null;
@@ -284,7 +287,8 @@ Bundle.create = function (opts, callback) {
     // Create and validate.
     const bundle = new Bundle({
       path: opts.bundle,
-      code: data.toString()
+      code: data.toString(),
+      allowEmpty: opts.allowEmpty
     });
 
     let err = null;

--- a/lib/parser/extractors.js
+++ b/lib/parser/extractors.js
@@ -9,6 +9,8 @@ const moduleTypes = require("../models/module-types");
 // Extracts the path from this string format:
 // !*** ../foo/awesomez.js ***!
 const extractPath = function (pathInfoComment) {
+  if (!(pathInfoComment || "").trim()) { return "UNKNOWN"; }
+
   const beginningToken = "!*** ";
   const endToken = " ***!";
 

--- a/lib/parser/matchers.js
+++ b/lib/parser/matchers.js
@@ -26,11 +26,8 @@ const isWebpackExportsComment = function (leadingComment) {
 };
 
 // Matches: /* 39 */
-// Also matches: /* ~/some/crazy/string/id */       <---- "nothing" ref
-//               /* ~/another/crazy/string/id */
 const isModuleIdLeadingComment = function (leadingComment) {
-  return !isPathinfoComment(leadingComment) &&
-    !isWebpackExportsComment(leadingComment);
+  return _.isFinite(parseInt(((leadingComment || {}).value || "").trim(), 10));
 };
 
 // Matches: /***/

--- a/lib/parser/matchers.js
+++ b/lib/parser/matchers.js
@@ -8,7 +8,8 @@ const t = require("babel-types");
 //   !*** ../foo/awesomez.js ***!
 //   \**************************/
 const isPathinfoComment = function (leadingComment) {
-  return leadingComment.value.indexOf("!*** ") !== -1;
+  const val = (leadingComment || {}).value || "";
+  return val.indexOf("!*** ") !== -1;
 };
 
 // TODO: determine if this can be more specific
@@ -21,18 +22,21 @@ const isWebpackFunctionExpression = function (node) {
             /* all exports used */
 // Only appears in Webpack 2 (tree shaking)
 const isWebpackExportsComment = function (leadingComment) {
-  return leadingComment.value.indexOf("exports provided") !== -1 ||
-    leadingComment.value.indexOf("exports used") !== -1;
+  const val = (leadingComment || {}).value || "";
+  return val.indexOf("exports provided") !== -1 ||
+    val.indexOf("exports used") !== -1;
 };
 
 // Matches: /* 39 */
 const isModuleIdLeadingComment = function (leadingComment) {
-  return _.isFinite(parseInt(((leadingComment || {}).value || "").trim(), 10));
+  const val = (leadingComment || {}).value || "";
+  return _.isFinite(parseInt(val.trim(), 10));
 };
 
 // Matches: /***/
 const hasWebpackAsteriskLeadingComment = _.find(leadingComment => {
-  return leadingComment.value === "*";
+  const val = (leadingComment || {}).value || "";
+  return val === "*";
 });
 
 // Is this actually a webpack module?

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-traverse": "^6.7.6",
     "babel-types": "^6.7.2",
     "babylon": "^6.7.0",
+    "formidable-playbook": "^0.1.0",
     "lodash": "^4.6.1",
     "mkdirp": "^0.5.1",
     "pify": "^2.3.0",

--- a/test/lib/parser/extractors.spec.js
+++ b/test/lib/parser/extractors.spec.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const expect = require("chai").expect;
+const extractors = require("../../../lib/parser/extractors");
+
+describe("lib/parser/extractors", () => {
+  describe("#getFileName", () => {
+    const getFileName = extractors.getFileName;
+    const wrapped = (value) => getFileName([{ value }]);
+
+    it("handles empty file names", () => {
+      expect(getFileName()).to.eql("UNKNOWN");
+      expect(getFileName(null)).to.eql("UNKNOWN");
+      expect(getFileName([])).to.eql("UNKNOWN");
+      expect(wrapped(null)).to.eql("UNKNOWN");
+      expect(wrapped("")).to.eql("UNKNOWN");
+      expect(wrapped("   ")).to.eql("UNKNOWN");
+    });
+
+    it("handles basic file names", () => {
+      expect(wrapped("!*** ./foo.js ***!")).to.eql("./foo.js");
+      expect(wrapped("!*** ./~/foo.js ***!")).to.eql("./~/foo.js");
+    });
+  });
+});

--- a/test/playbook.spec.js
+++ b/test/playbook.spec.js
@@ -67,7 +67,7 @@ describe("playbook", () => {
       format: "object",
       minified: false,
       gzip: false
-    }, (err, result) => {
+    }, (err) => {
       expect(err)
         .to.be.ok.and
         .to.have.property("message")
@@ -106,6 +106,9 @@ describe("playbook", () => {
       });
     });
 
+    // TODO(RYAN): Update fileName for delegated file reference?
+    // - https://github.com/FormidableLabs/inspectpack/issues/36
+    // - https://github.com/FormidableLabs/inspectpack/issues/37
     it("parses consuming bundles", (done) => {
       sizes({
         code: fixtures.sharedLibs.app1,
@@ -113,13 +116,24 @@ describe("playbook", () => {
         minified: false,
         gzip: false
       }, (err, result) => {
-        console.log(err, result);
+        finishAsserts(done, err, () => {
+          expect(result).to.have.property("sizes").that.has.lengthOf(3);
 
-        done();
+          const codes = result.sizes;
+          expect(codes[0]).to.have.property("id", "0");
+          expect(codes[0]).to.have.property("fileName",
+            "delegated ./foo.js from dll-reference lib_00d73d25eef8ddd2ed11");
+          expect(codes[0]).to.have.property("type", "code");
+
+          expect(codes[1]).to.have.property("id", "1");
+          expect(codes[1]).to.have.property("fileName", "external \"lib_00d73d25eef8ddd2ed11\"");
+          expect(codes[1]).to.have.property("type", "code");
+
+          expect(codes[2]).to.have.property("id", "2");
+          expect(codes[2]).to.have.property("fileName", "./app1.js");
+          expect(codes[2]).to.have.property("type", "code");
+        });
       });
     });
-
   });
-
-
 });

--- a/test/playbook.spec.js
+++ b/test/playbook.spec.js
@@ -16,7 +16,7 @@ const EXTENDED_TIMEOUT = 15000;
 const fixtureRoot = path.dirname(require.resolve("formidable-playbook/package.json"));
 const readFile = (relPath) => fs.readFileSync(path.join(fixtureRoot, relPath), "utf8");
 
-describe("playbook", () => {
+describe("Playbook", () => {
   let fixtures;
 
   before(function () {

--- a/test/playbook.spec.js
+++ b/test/playbook.spec.js
@@ -77,7 +77,19 @@ describe("playbook", () => {
     });
   });
 
-  it("allows empty bundles with flag"); // TODO: IMPLEMENT
+  it("allows empty bundles with flag", (done) => {
+    sizes({
+      code: fixtures.sourceMaps.app1,
+      allowEmpty: true,
+      format: "object",
+      minified: false,
+      gzip: false
+    }, (err, result) => {
+      finishAsserts(done, err, () => {
+        expect(result).to.have.property("sizes").that.has.lengthOf(0);
+      });
+    });
+  });
 
   describe("dll / shared libs", () => {
     it("parses shared libraries", (done) => {

--- a/test/playbook.spec.js
+++ b/test/playbook.spec.js
@@ -80,14 +80,13 @@ describe("playbook", () => {
   it("allows empty bundles with flag"); // TODO: IMPLEMENT
 
   describe("dll / shared libs", () => {
-    it.skip("parses shared libraries", (done) => {
+    it("parses shared libraries", (done) => {
       sizes({
         code: fixtures.sharedLibs.lib,
         format: "object",
         minified: false,
         gzip: false
       }, (err, result) => {
-        console.log(result);
         finishAsserts(done, err, () => {
           expect(result).to.have.property("sizes").that.has.lengthOf(3);
 

--- a/test/playbook.spec.js
+++ b/test/playbook.spec.js
@@ -77,5 +77,50 @@ describe("playbook", () => {
     });
   });
 
+  it("allows empty bundles with flag"); // TODO: IMPLEMENT
+
+  describe("dll / shared libs", () => {
+    it.skip("parses shared libraries", (done) => {
+      sizes({
+        code: fixtures.sharedLibs.lib,
+        format: "object",
+        minified: false,
+        gzip: false
+      }, (err, result) => {
+        console.log(result);
+        finishAsserts(done, err, () => {
+          expect(result).to.have.property("sizes").that.has.lengthOf(3);
+
+          const codes = result.sizes;
+          expect(codes[0]).to.have.property("id", "0");
+          expect(codes[0]).to.have.property("fileName", "dll lib");
+          expect(codes[0]).to.have.property("type", "code");
+
+          expect(codes[1]).to.have.property("id", "1");
+          expect(codes[1]).to.have.property("fileName", "./lib.js");
+          expect(codes[1]).to.have.property("type", "code");
+
+          expect(codes[2]).to.have.property("id", "2");
+          expect(codes[2]).to.have.property("fileName", "./foo.js");
+          expect(codes[2]).to.have.property("type", "code");
+        });
+      });
+    });
+
+    it("parses consuming bundles", (done) => {
+      sizes({
+        code: fixtures.sharedLibs.app1,
+        format: "object",
+        minified: false,
+        gzip: false
+      }, (err, result) => {
+        console.log(err, result);
+
+        done();
+      });
+    });
+
+  });
+
 
 });

--- a/test/playbook.spec.js
+++ b/test/playbook.spec.js
@@ -1,0 +1,81 @@
+"use strict";
+
+/**
+ * Tests using `formidable-playbook` fixtures.
+ */
+const fs = require("fs");
+const path = require("path");
+const expect = require("chai").expect;
+
+const sizes = require("../lib/actions/sizes");
+
+const finishAsserts = require("./util").finishAsserts;
+
+const EXTENDED_TIMEOUT = 15000;
+
+const fixtureRoot = path.dirname(require.resolve("formidable-playbook/package.json"));
+const readFile = (relPath) => fs.readFileSync(path.join(fixtureRoot, relPath), "utf8");
+
+describe("playbook", () => {
+  let fixtures;
+
+  before(function () {
+    this.timeout(EXTENDED_TIMEOUT);
+
+    fixtures = {
+      codeSplittingEnsure: [
+        "0",
+        "1",
+        "2",
+        "entry"
+      ].reduce((m, k) => Object.assign(m, {
+        [k]: readFile(`examples/frontend/webpack-code-splitting-ensure/dist/js/${k}.js`)
+      }), {}),
+      codeSplitting: [
+        "app1",
+        "app2",
+        "commons"
+      ].reduce((m, k) => Object.assign(m, {
+        [k]: readFile(`examples/frontend/webpack-code-splitting/dist/js/${k}.js`)
+      }), {}),
+      sharedLibs: [
+        "app1",
+        "app2",
+        "lib"
+      ].reduce((m, k) => Object.assign(m, {
+        [k]: readFile(`examples/frontend/webpack-shared-libs/dist/js/${k}.js`)
+      }), {}),
+      // Minified, no pathinfo
+      sourceMaps: [
+        "app1",
+        "app2"
+      ].reduce((m, k) => Object.assign(m, {
+        [k]: readFile(`examples/frontend/webpack-source-maps/dist/js/${k}.js`)
+      }), {}),
+      treeShaking: [
+        "app1",
+        "app2"
+      ].reduce((m, k) => Object.assign(m, {
+        [k]: readFile(`examples/frontend/webpack-tree-shaking/dist/js/${k}.js`)
+      }), {})
+    };
+  });
+
+  it("throws on no code found / minified / no pathinfo", (done) => {
+    sizes({
+      code: fixtures.sourceMaps.app1,
+      format: "object",
+      minified: false,
+      gzip: false
+    }, (err, result) => {
+      expect(err)
+        .to.be.ok.and
+        .to.have.property("message")
+          .that.contains("No code sections found");
+
+      done();
+    });
+  });
+
+
+});

--- a/test/smoke.spec.js
+++ b/test/smoke.spec.js
@@ -110,6 +110,23 @@ describe("Smoke tests", () => {
     }, (err, result) => {
       finishAsserts(done, err, () => {
         expect(result).to.have.property("sizes").with.lengthOf(4);
+
+        const codes = result.sizes;
+        expect(codes[0]).to.have.property("id", "1");
+        expect(codes[0]).to.have.property("fileName", "(webpack)/buildin/global.js");
+        expect(codes[0]).to.have.property("type", "code");
+
+        expect(codes[1]).to.have.property("id", "15");
+        expect(codes[1]).to.have.property("baseName", "(webpack)/buildin/module.js");
+        expect(codes[1]).to.have.property("type", "code");
+
+        expect(codes[2]).to.have.property("id", "36");
+        expect(codes[2]).to.have.property("baseName", "lodash/lodash.js");
+        expect(codes[2]).to.have.property("type", "code");
+
+        expect(codes[3]).to.have.property("id", "39");
+        expect(codes[3]).to.have.property("baseName", "./demo/index.js");
+        expect(codes[3]).to.have.property("type", "code");
       });
     });
   });

--- a/test/smoke.spec.js
+++ b/test/smoke.spec.js
@@ -101,7 +101,37 @@ describe("Smoke tests", () => {
     });
   });
 
-  it("analyzes bundle sizes", (done) => {
+  it("analyzes bundle sizes in bad fixture", (done) => {
+    sizes({
+      code: badBundleFixture,
+      format: "object",
+      minified: false,
+      gzip: false
+    }, (err, result) => {
+      finishAsserts(done, err, () => {
+        expect(result).to.have.property("sizes").with.lengthOf(125);
+
+        const codes = result.sizes;
+        expect(codes[0]).to.have.property("id", "0");
+        expect(codes[0]).to.have.property("baseName", "moment/moment.js");
+        expect(codes[0]).to.have.property("type", "code");
+
+        expect(codes[1]).to.have.property("id", "1");
+        expect(codes[1]).to.have.property("fileName", "(webpack)/buildin/module.js");
+        expect(codes[1]).to.have.property("type", "code");
+
+        expect(codes[2]).to.have.property("id", "2");
+        expect(codes[2]).to.have.property("baseName", "(webpack)/buildin/global.js");
+        expect(codes[2]).to.have.property("type", "code");
+
+        expect(codes[124]).to.have.property("id", "124");
+        expect(codes[124]).to.have.property("baseName", "./src/bad-bundle.js");
+        expect(codes[124]).to.have.property("type", "code");
+      });
+    });
+  });
+
+  it("analyzes bundle sizes in basic fixture", (done) => {
     sizes({
       code: basicFixture,
       format: "object",

--- a/test/smoke.spec.js
+++ b/test/smoke.spec.js
@@ -1,8 +1,8 @@
 "use strict";
 
-const expect = require("chai").expect;
 const fs = require("fs");
 const path = require("path");
+const expect = require("chai").expect;
 
 const duplicates = require("../lib/actions/duplicates");
 const pattern = require("../lib/actions/pattern");
@@ -19,16 +19,7 @@ const readFile = (relPath) => fs.readFileSync(path.join(fixtureRoot, relPath), "
 const basicFixture = readFile("built/basic-lodash-object-expression.js");
 const badBundleFixture = readFile("dist/bad-bundle.js");
 
-const checkForErrors = function (done, err, assertion) {
-  if (err) { return void done(err); }
-
-  try {
-    assertion();
-    done();
-  } catch (e) {
-    done(e);
-  }
-};
+const finishAsserts = require("./util").finishAsserts;
 
 describe("Smoke tests", () => {
   before(function () {
@@ -42,7 +33,7 @@ describe("Smoke tests", () => {
       minified: false,
       gzip: false
     }, (err, result) => {
-      checkForErrors(done, err, () => {
+      finishAsserts(done, err, () => {
         expect(result).to.have.deep.property("meta.numFilesWithDuplicates", 1);
       });
     });
@@ -56,7 +47,7 @@ describe("Smoke tests", () => {
       minified: false,
       gzip: false
     }, (err, result) => {
-      checkForErrors(done, err, () => {
+      finishAsserts(done, err, () => {
         expect(result).to.have.deep.property("meta.numMatches", 2);
       });
     });
@@ -75,7 +66,7 @@ describe("Smoke tests", () => {
       minified: false,
       gzip: false
     }, (err, result) => {
-      checkForErrors(done, err, () => {
+      finishAsserts(done, err, () => {
         expect(result).to.have.deep.property("meta.numMatches", 1);
       });
     });
@@ -90,7 +81,7 @@ describe("Smoke tests", () => {
       gzip: false
 
     }, (err, result) => {
-      checkForErrors(done, err, () => {
+      finishAsserts(done, err, () => {
         expect(result).to.have.deep.property("meta.numMatches", 5);
       });
     });
@@ -104,7 +95,7 @@ describe("Smoke tests", () => {
       minified: false,
       gzip: false
     }, (err, result) => {
-      checkForErrors(done, err, () => {
+      finishAsserts(done, err, () => {
         expect(result).to.have.property("versions");
       });
     });
@@ -117,7 +108,7 @@ describe("Smoke tests", () => {
       minified: false,
       gzip: false
     }, (err, result) => {
-      checkForErrors(done, err, () => {
+      finishAsserts(done, err, () => {
         expect(result).to.have.property("sizes").with.lengthOf(4);
       });
     });

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const finishAsserts = function (done, err, assertion) {
+  if (err) { return void done(err); }
+
+  try {
+    assertion();
+    done();
+  } catch (e) {
+    done(e);
+  }
+};
+
+module.exports = {
+  finishAsserts
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,6 +1054,10 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+formidable-playbook@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/formidable-playbook/-/formidable-playbook-0.1.0.tgz#e231031b69e34e4960b38fe7ed5c105961c047ca"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"


### PR DESCRIPTION
I've added more tests using the `formidable-playbook` fixtures for more scenarios. There's still a lot more that we can do with those...

## Notes

* Add `formidable-playbook` as fixtures.
* Add basic DLL tests
* Assert on module id parsing (and fix it).
* Handle a wide range of bad inputs on parser matches + test. Fixes FormidableLabs/electron-webpack-dashboard#10
* Add `allowEmpty` action option / `--allow-empty` CLI flag to not throw errors when passing in a minified bundle / bundle with `pathinfo` / anything `inspectpack` _can't_ parse. This is one option to enable and hopefully silence errors in FormidableLabs/electron-webpack-dashboard#1 although note that there will be no inspectpack stats. I have filed a future research issue to investigate using `stats.json` as an alternate path to information for `inspectpack` as a new option in #41 

## Future work

* More tests with playbook fixtures for different scenarios.
* Investigate DLL desired refactor more for #36 ( @Trakkasure - I could use some help defining what we want to do / change )

/cc @tptee @kenwheeler 