### PR TITLE
Upgrade to uglify-es

### DIFF
--- a/lib/actions/duplicates.js
+++ b/lib/actions/duplicates.js
@@ -4,7 +4,7 @@ const zlib = require("zlib");
 const util = require("util");
 
 const _ = require("lodash/fp");
-const uglify = require("uglify-js");
+const uglify = require("uglify-es");
 
 const Base = require("./base");
 const metaSum = require("../utils/data").metaSum;
@@ -41,7 +41,6 @@ const addSizes = function (codes, opts) {
       const codeSrc = toParseable(_.find({ id: idx })(codes).code);
       const fullSize = codeSrc.length;
       const minSrc = minified ? uglify.minify(codeSrc, {
-        fromString: true,
         warnings: false,
         output: {
           // eslint-disable-next-line camelcase
@@ -175,7 +174,6 @@ Duplicates.prototype.getData = function (callback) {
   const numFilesWithDuplicates = _.keys(data).length;
   const numAllFiles = metaSum("uniqIdxs.length")(data);
   const minSrc = minified ? uglify.minify(bundle.code, {
-    fromString: true,
     warnings: false,
     output: {
       // eslint-disable-next-line camelcase

--- a/lib/utils/compressor.js
+++ b/lib/utils/compressor.js
@@ -1,13 +1,12 @@
 "use strict";
 
-const uglify = require("uglify-js");
+const uglify = require("uglify-es");
 const zlib = require("zlib");
 
 const Cache = require("./cache");
 const hash = require("./hash");
 
 const DEFAULT_UGLIFY_OPTS = {
-  fromString: true,
   warnings: false,
   output: {
     // eslint-disable-next-line camelcase

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lodash": "^4.6.1",
     "mkdirp": "^0.5.1",
     "pify": "^2.3.0",
-    "uglify-js": "^2.6.2",
+    "uglify-es": "^3.0.28",
     "workerpool": "^2.2.1",
     "yargs": "^4.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -491,6 +491,10 @@ commander@2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commander@~2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -2524,6 +2528,13 @@ type-detect@^1.0.0:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+uglify-es@^3.0.28:
+  version "3.0.28"
+  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.0.28.tgz#1cdedbbcdb7865223065281ad7b2347629851d4b"
+  dependencies:
+    commander "~2.11.0"
+    source-map "~0.5.1"
 
 uglify-js@^2.6.2, uglify-js@^2.8.5:
   version "2.8.22"


### PR DESCRIPTION
This lets us handle webpack projects that use `uglify-es` (e.g. Node projects that bundle without transpilation)!