### PR TITLE
Bug: Fix bad sourcemaps parsing.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
 History
 =======
 
+## Unreleased
+
+* Fix over-truncating `sourceMappingUrl` comment removal.
+
 ## 1.2.2
 
 * Improve module ID comment inference logic.

--- a/lib/parser/extractors.js
+++ b/lib/parser/extractors.js
@@ -105,7 +105,7 @@ const getModuleType = function (node) {
 // //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uI..."
 const removeSourceMap = function (rawCode) {
   return rawCode && rawCode
-    //.replace(/\/\/# sourceMappingURL=[^"]*/g, "") || "";
+    .replace(/\/\/# sourceMappingURL=[^"]*/g, "") || "";
 };
 
 // Extract the "real" code from Webpack's eval() source map wrapper.

--- a/lib/parser/extractors.js
+++ b/lib/parser/extractors.js
@@ -105,7 +105,7 @@ const getModuleType = function (node) {
 // //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uI..."
 const removeSourceMap = function (rawCode) {
   return rawCode && rawCode
-    .replace(/\/\/# sourceMappingURL=[^"]*/g, "") || "";
+    .replace(/\/\/# sourceMappingURL=[^\r\n]*[\r\n]+/g, "") || "";
 };
 
 // Extract the "real" code from Webpack's eval() source map wrapper.

--- a/lib/parser/extractors.js
+++ b/lib/parser/extractors.js
@@ -105,7 +105,7 @@ const getModuleType = function (node) {
 // //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uI..."
 const removeSourceMap = function (rawCode) {
   return rawCode && rawCode
-    .replace(/\/\/# sourceMappingURL=[^"]*/g, "") || "";
+    //.replace(/\/\/# sourceMappingURL=[^"]*/g, "") || "";
 };
 
 // Extract the "real" code from Webpack's eval() source map wrapper.

--- a/lib/utils/compressor.js
+++ b/lib/utils/compressor.js
@@ -120,18 +120,14 @@ module.exports = class Compressor {
           return Promise.reject(result.error);
         }
 
-        // TODO(ryan): unwind unneeded Promise.all
-        return Promise.all([
-          Promise.resolve(result.code.length),
-          getGzipLength(
-            Object.assign({}, opts, {
-              source: result.code
-            })
-          )
-        ]).then(compressedSizes =>
+        return getGzipLength(
+          Object.assign({}, opts, {
+            source: result.code
+          })
+        ).then(minGz =>
           Object.assign({}, sizes, {
-            min: compressedSizes[0],
-            minGz: compressedSizes[1]
+            min: result.code.length,
+            minGz
           }));
       })
       .then(fullSizes => {

--- a/lib/utils/compressor.js
+++ b/lib/utils/compressor.js
@@ -11,8 +11,7 @@ const DEFAULT_UGLIFY_OPTS = {
   output: {
     // eslint-disable-next-line camelcase
     max_line_len: Infinity
-  },
-  sourceMap: false
+  }
 };
 
 const DEFAULT_GZIP_OPTS = { level: 9 };

--- a/lib/utils/compressor.js
+++ b/lib/utils/compressor.js
@@ -11,7 +11,8 @@ const DEFAULT_UGLIFY_OPTS = {
   output: {
     // eslint-disable-next-line camelcase
     max_line_len: Infinity
-  }
+  },
+  sourceMap: false
 };
 
 const DEFAULT_GZIP_OPTS = { level: 9 };
@@ -114,8 +115,14 @@ module.exports = class Compressor {
     }
 
     return minify(opts)
-      .then(result =>
-        Promise.all([
+      .then(result => {
+        if (result.error) {
+          console.log("TODO HERE", opts.source, result.error);
+          return Promise.reject(result.error);
+        }
+
+        // TODO(ryan): unwind unneeded Promise.all
+        return Promise.all([
           Promise.resolve(result.code.length),
           getGzipLength(
             Object.assign({}, opts, {
@@ -126,7 +133,8 @@ module.exports = class Compressor {
           Object.assign({}, sizes, {
             min: compressedSizes[0],
             minGz: compressedSizes[1]
-          })))
+          }));
+      })
       .then(fullSizes => {
         if (this._cache) {
           this._cache.set(hashedKey, fullSizes);

--- a/lib/utils/compressor.js
+++ b/lib/utils/compressor.js
@@ -117,7 +117,7 @@ module.exports = class Compressor {
     return minify(opts)
       .then(result => {
         if (result.error) {
-          console.log("TODO HERE", opts.source, result.error);
+          console.log("TODO HERE", opts.source);
           return Promise.reject(result.error);
         }
 

--- a/lib/utils/compressor.js
+++ b/lib/utils/compressor.js
@@ -117,7 +117,6 @@ module.exports = class Compressor {
     return minify(opts)
       .then(result => {
         if (result.error) {
-          console.log("TODO HERE", opts.source);
           return Promise.reject(result.error);
         }
 

--- a/test/lib/parser/extractors.spec.js
+++ b/test/lib/parser/extractors.spec.js
@@ -2,6 +2,7 @@
 
 const expect = require("chai").expect;
 const extractors = require("../../../lib/parser/extractors");
+const moduleTypes = require("../../../lib/models/module-types");
 
 describe("lib/parser/extractors", () => {
   describe("#getFileName", () => {
@@ -23,9 +24,32 @@ describe("lib/parser/extractors", () => {
     });
   });
 
-  describe("#getCode", () => {
-    it("handles empty code");
-    it("removes inline source mapping comments");
+  describe.only("#getCode", () => {
+    const getCode = extractors.getCode;
+    const wrapped = (value) => getCode({
+      start: 0, end: value.length
+    }, moduleTypes.CODE, value);
+
+    it("handles empty code", () => {
+      expect(wrapped("")).to.equal("");
+      expect(wrapped("    ")).to.equal("    ");
+    });
+
+    it("handles basic code", () => {
+      const val = `
+var foo = 'foo';
+var bar = 'bar';
+`;
+      expect(wrapped(val)).to.equal(val);
+    });
+
+    it("removes inline source mapping comments", () => {
+      expect(wrapped(`
+var foo = 'foo';
+//# sourceMappingURL=foo.js.map
+      `).trim()).to.equal("var foo = 'foo';");
+    });
+
     it("preserves code after source mapping comments");
   });
 });

--- a/test/lib/parser/extractors.spec.js
+++ b/test/lib/parser/extractors.spec.js
@@ -50,6 +50,16 @@ var foo = 'foo';
       `).trim()).to.equal("var foo = 'foo';");
     });
 
-    it("preserves code after source mapping comments");
+    // Regression Test: https://github.com/FormidableLabs/webpack-dashboard/issues/182
+    it("preserves code after source mapping comments", () => {
+      expect(wrapped(`
+var foo = 'foo';
+//# sourceMappingURL=foo.js.map
+
+var bar = 'bar';
+      `).trim()).to.equal("var foo = 'foo';\nvar bar = 'bar';");
+    });
+
+    it("extracts webpack eval source map"); // TODO: GET SAMPLE
   });
 });

--- a/test/lib/parser/extractors.spec.js
+++ b/test/lib/parser/extractors.spec.js
@@ -22,4 +22,10 @@ describe("lib/parser/extractors", () => {
       expect(wrapped("!*** ./~/foo.js ***!")).to.eql("./~/foo.js");
     });
   });
+
+  describe("#getCode", () => {
+    it("handles empty code");
+    it("removes inline source mapping comments");
+    it("preserves code after source mapping comments");
+  });
 });

--- a/test/lib/parser/extractors.spec.js
+++ b/test/lib/parser/extractors.spec.js
@@ -24,7 +24,7 @@ describe("lib/parser/extractors", () => {
     });
   });
 
-  describe.only("#getCode", () => {
+  describe("#getCode", () => {
     const getCode = extractors.getCode;
     const wrapped = (value) => getCode({
       start: 0, end: value.length
@@ -58,8 +58,18 @@ var foo = 'foo';
 
 var bar = 'bar';
       `).trim()).to.equal("var foo = 'foo';\nvar bar = 'bar';");
+
+      expect(wrapped(`
+var foo = 'foo';
+//# sourceMappingURL=foo.js.map
+
+var bar = 'bar';
+//# sourceMappingURL=bar.js.map
+
+var baz = 'baz';
+      `).trim()).to.equal("var foo = 'foo';\nvar bar = 'bar';\nvar baz = 'baz';");
     });
 
-    it("extracts webpack eval source map"); // TODO: GET SAMPLE
+    it("extracts webpack eval source map"); // TODO: Find example.
   });
 });

--- a/test/lib/utils/compressor.spec.js
+++ b/test/lib/utils/compressor.spec.js
@@ -20,7 +20,7 @@ const EMPTY_SIZES_GZ = {
   minGz: 20 // (Cost of empty gzipping)
 };
 
-describe.only("lib/utils/compressor", () => {
+describe("lib/utils/compressor", () => {
   describe("#getFileName", () => {
     const create = (opts) => new Compressor(opts);
 

--- a/test/lib/utils/compressor.spec.js
+++ b/test/lib/utils/compressor.spec.js
@@ -11,8 +11,8 @@ const Compressor = require("../../../lib/utils/compressor");
 
 const EMPTY_SIZES = {
   full: 0,
-  min: '--',
-  minGz: '--'
+  min: "--",
+  minGz: "--"
 };
 const EMPTY_SIZES_GZ = {
   full: 0,
@@ -47,7 +47,7 @@ describe("lib/utils/compressor", () => {
             full: 4
           }));
         })
-      ])
+      ]);
     });
 
     it("handles basic bundles", () => {
@@ -80,7 +80,7 @@ describe("lib/utils/compressor", () => {
         source: "**SYNTAX_ERROR**",
         minified: true, gzip: true
       }).then(sizes => {
-        throw new Error("Expected failure. Instead got: " + JSON.stringify(sizes));
+        throw new Error(`Expected failure. Instead got: ${JSON.stringify(sizes)}`);
       }).catch(err => {
         expect(err).to.have.property("message", "Unexpected token: operator (**)");
       });
@@ -94,7 +94,8 @@ describe("lib/utils/compressor", () => {
 a=(function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return UPDATE_LOCATION; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a",
+function() { return UPDATE_LOCATION; });
 var UPDATE_LOCATION = "@angular-redux/router::UPDATE_LOCATION";
 //# sourceMappingURL=actions.js.map
 

--- a/test/lib/utils/compressor.spec.js
+++ b/test/lib/utils/compressor.spec.js
@@ -1,0 +1,51 @@
+"use strict";
+
+const expect = require("chai").expect;
+const Compressor = require("../../../lib/utils/compressor");
+
+const EMPTY_SIZES = {
+  full: 0,
+  min: '--',
+  minGz: '--'
+};
+const EMPTY_SIZES_GZ = {
+  full: 0,
+  min: 0,
+  minGz: 20 // (Cost of empty gzipping)
+};
+
+describe.only("lib/utils/compressor", () => {
+  describe("#getFileName", () => {
+    const create = (opts) => new Compressor(opts);
+
+    it("handles empty bundles", () => {
+      const comp = create();
+
+      return Promise.all([
+        comp.getSizes({ source: "" }).then(sizes => {
+          expect(sizes).to.eql(EMPTY_SIZES);
+        }),
+
+        comp.getSizes({ source: "", minified: true, gzip: true }).then(sizes => {
+          expect(sizes).to.eql(EMPTY_SIZES_GZ);
+        }),
+
+        comp.getSizes({ source: "    " }).then(sizes => {
+          expect(sizes).to.eql(Object.assign({}, EMPTY_SIZES, {
+            full: 4
+          }));
+        }),
+
+        comp.getSizes({ source: "    ", minified: true, gzip: true }).then(sizes => {
+          expect(sizes).to.eql(Object.assign({}, EMPTY_SIZES_GZ, {
+            full: 4
+          }));
+        })
+      ])
+    });
+
+    it("handles basic bundles");
+
+    it("handles source map comments");
+  });
+});

--- a/test/lib/utils/compressor.spec.js
+++ b/test/lib/utils/compressor.spec.js
@@ -1,5 +1,11 @@
 "use strict";
 
+/**
+ * **Note - Min, GZ**: We're using the current output values for minification
+ * and gzipping, but these are pretty brittle constructs because the libraries
+ * could change under the hood...
+ */
+
 const expect = require("chai").expect;
 const Compressor = require("../../../lib/utils/compressor");
 
@@ -44,8 +50,64 @@ describe.only("lib/utils/compressor", () => {
       ])
     });
 
-    it("handles basic bundles");
+    it("handles basic bundles", () => {
+      const comp = create();
 
-    it("handles source map comments");
+      return Promise.all([
+        comp.getSizes({
+          source: "const foo = () => 'foo';"
+        }).then(sizes => {
+          expect(sizes).to.eql(Object.assign({}, EMPTY_SIZES, {
+            full: 24
+          }));
+        }),
+
+        comp.getSizes({
+          source: "const foo = () => 'foo';",
+          minified: true, gzip: true
+        }).then(sizes => {
+          expect(sizes).to.eql({
+            full: 24,
+            min: 20,
+            minGz: 38
+          });
+        })
+      ]);
+    });
+
+    it("rejects with error on syntax error", () => {
+      return create().getSizes({
+        source: "**SYNTAX_ERROR**",
+        minified: true, gzip: true
+      }).then(sizes => {
+        throw new Error("Expected failure. Instead got: " + JSON.stringify(sizes));
+      }).catch(err => {
+        expect(err).to.have.property("message", "Unexpected token: operator (**)");
+      });
+    });
+
+    // Regression Test: https://github.com/FormidableLabs/webpack-dashboard/issues/182
+    // (Didn't originally fail, but larger path to process).
+    it("handles source map comments", () => {
+      return create().getSizes({
+        source: `
+a=(function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return UPDATE_LOCATION; });
+var UPDATE_LOCATION = "@angular-redux/router::UPDATE_LOCATION";
+//# sourceMappingURL=actions.js.map
+
+/***/ })
+`,
+        minified: true, gzip: true
+      }).then(sizes => {
+        expect(sizes).to.eql({
+          full: 310,
+          min: 111,
+          minGz: 124
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
In working through FormidableLabs/webpack-dashboard#182 at a minimum, we have a bug where `inspectpack` removes all lines _after_ a `sourceMappingUrl` comment, which it should just remove the entire line and nothing after.

Changes:

- Add regression test for `sourceMappingUrl` over-truncation bug.
- Add more general tests for extractor and compressor
- Fix sourcemapping comment removal
- Refactor out unnecessary Promise.all in code.
- Better JS parsing errors from minifier.

/cc @tptee @kenwheeler 