### PR TITLE
Use sqlite to back cache and enable multiprocessing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ build
 coverage
 Procfile
 .lankrc*
+test-output

--- a/lib/daemon/index.js
+++ b/lib/daemon/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const { tap } = require("lodash/fp");
-const { cpus } = require("os");
+const tap = require("lodash/fp").tap;
+const cpus = require("os").cpus;
 const path = require("path");
 const workerpool = require("workerpool");
 
@@ -17,7 +17,8 @@ class InspectpackDaemon {
    * @param {Object} opts.cacheFilename    The filename of the daemon cache
    * @returns {InspectpackDaemon} The daemon with cache
    */
-  static create(opts = {}) {
+  static create(opts) {
+    opts = opts || {};
     const cache = Cache.create({ filename: opts.cacheFilename });
     return new InspectpackDaemon(cache, opts);
   }

--- a/lib/daemon/index.js
+++ b/lib/daemon/index.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { tap } = require("lodash/fp");
+const { cpus } = require("os");
 const path = require("path");
 const workerpool = require("workerpool");
 
@@ -12,18 +14,12 @@ class InspectpackDaemon {
    * Start the daemon with an asynchronously initialized cache.
    *
    * @param {Object} opts                  Object options
-   * @param {Object} opts.cacheDir         The directory to store cache files in
-   * @returns {Promise<InspectpackDaemon>} The daemon with cache
+   * @param {Object} opts.cacheFilename    The filename of the daemon cache
+   * @returns {InspectpackDaemon} The daemon with cache
    */
-  static init(opts) {
-    opts = opts || {};
-
-    return Cache.init({
-      scope: "action-results",
-      cacheDir: opts.cacheDir
-    }).then(
-      cache => new InspectpackDaemon(cache, opts)
-    );
+  static init(opts = {}) {
+    const cache = Cache.create({ filename: opts.cacheFilename });
+    return new InspectpackDaemon(cache, opts);
   }
 
   /**
@@ -31,15 +27,15 @@ class InspectpackDaemon {
    *
    * @param {Cache} cache                  An existing cache instance
    * @param {Object} opts                  Object options
-   * @param {Object} opts.cacheDir         The directory to store cache files in
+   * @param {Object} opts.cacheFilename    The filename of the daemon cache
    */
   constructor(cache, opts) {
     this._cache = cache || null;
-    this._cacheDir = opts.cacheDir || null;
+    this._cacheFilename = opts.cacheFilename || null;
     this._pool = workerpool.pool(path.resolve(__dirname, "worker.js"), {
-      minWorkers: 1,
-      maxWorkers: 1,
-      forkArgs: [`cacheDir=${this._cacheDir}`]
+      minWorkers: cpus().length,
+      maxWorkers: cpus().length,
+      forkArgs: [`cacheFilename=${this._cacheFilename}`]
     });
   }
 
@@ -57,22 +53,20 @@ class InspectpackDaemon {
 // The generated methods look like `daemon.sizes(...).then(...)`
 Object.keys(actions.ACTIONS).forEach(action => {
   InspectpackDaemon.prototype[action] = function (opts) {
-    const hashedKey = hash({ action, opts });
-
-    if (this._cache) {
-      const cachedValue = this._cache.get(hashedKey);
-      if (cachedValue) {
-        return Promise.resolve(cachedValue);
-      }
+    if (!this._cache) {
+      return this._pool.exec(action, [opts]);
     }
 
-    return this._pool.exec(action, [opts]).then(result => {
-      if (this._cache) {
-        this._cache.set(hashedKey, result);
-        this._cache.save();
-      }
-      return result;
-    });
+    const hashedKey = hash({ action, opts });
+    const cachedValue = this._cache.get(hashedKey);
+    if (cachedValue) {
+      return Promise.resolve(cachedValue);
+    }
+
+    return this._pool.exec(action, [opts])
+      .then(tap(result =>
+        this._cache.set(hashedKey, result)
+      ));
   };
 });
 

--- a/lib/daemon/index.js
+++ b/lib/daemon/index.js
@@ -17,7 +17,7 @@ class InspectpackDaemon {
    * @param {Object} opts.cacheFilename    The filename of the daemon cache
    * @returns {InspectpackDaemon} The daemon with cache
    */
-  static init(opts = {}) {
+  static create(opts = {}) {
     const cache = Cache.create({ filename: opts.cacheFilename });
     return new InspectpackDaemon(cache, opts);
   }

--- a/lib/daemon/worker.js
+++ b/lib/daemon/worker.js
@@ -5,10 +5,10 @@ const workerpool = require("workerpool");
 const actions = require("../actions");
 const Compressor = require("../utils/compressor");
 
-const cacheDirArg = process.argv
-  .find(arg => arg.indexOf("cacheDir=") !== -1);
-const cacheDir = cacheDirArg && cacheDirArg
-  .replace("cacheDir=", "");
+const cacheFilenameArg = process.argv
+  .find(arg => arg.indexOf("cacheFilename=") !== -1);
+const filename = cacheFilenameArg && cacheFilenameArg
+  .replace("cacheFilename=", "");
 
 // Create worker methods for each corresponding action.
 // The generated methods look like `sizes(...).then(...)`
@@ -20,24 +20,21 @@ const wrapMethod = (action, compressor) => args =>
         if (err) {
           return reject(err);
         }
-        compressor.saveCache();
         return resolve(result);
       }
     ));
 
 // Create each action method, injecting a compressor
 // instance for each one.
-Promise.all(
-  Object.keys(actions.ACTIONS).map(action =>
-    Compressor.init({
-      scope: `${action}-compressor`,
-      cacheDir
-    }).then(compressor => ({
-      [action]: wrapMethod(action, compressor)
-    })))
-)
-  .then(actionMaps =>
-    actionMaps.reduce((acc, map) =>
-      Object.assign({}, acc, map), {})
+workerpool.worker(
+  Object.keys(actions.ACTIONS)
+    .map(action => ({
+      [action]: wrapMethod(
+        action,
+        Compressor.create({ filename })
+      )
+    }))
+    .reduce((acc, map) =>
+      Object.assign({}, acc, map), {}
     )
-  .then(workerpool.worker);
+);

--- a/lib/daemon/worker.js
+++ b/lib/daemon/worker.js
@@ -27,14 +27,13 @@ const wrapMethod = (action, compressor) => args =>
 // Create each action method, injecting a compressor
 // instance for each one.
 workerpool.worker(
-  Object.keys(actions.ACTIONS)
-    .map(action => ({
+  Object.keys(actions.ACTIONS).reduce(
+    (acc, action) => Object.assign({}, acc, {
       [action]: wrapMethod(
         action,
         Compressor.create({ filename })
       )
-    }))
-    .reduce((acc, map) =>
-      Object.assign({}, acc, map), {}
-    )
+    }),
+    {}
+  )
 );

--- a/lib/utils/cache.js
+++ b/lib/utils/cache.js
@@ -1,96 +1,57 @@
 "use strict";
 
-const path = require("path");
-const fs = require("fs");
-const tmpdir = require("os").tmpdir;
+const createDebugLogger = require("debug");
+const { flow, get } = require("lodash/fp");
+const Database = require("better-sqlite3");
 
-const pify = require("pify");
-const mkdirp = pify(require("mkdirp"));
-const toPairs = require("lodash/fp/toPairs");
+const SafeJSON = require("./safe-json");
 
-const DEFAULT_FILENAME = "default-cache.json";
+const DEFAULT_DATABASE = ".inspectpack-cache.db";
+const DEFAULT_NAME = "inspectpack-cache";
 
-const readFile = pify(fs.readFile);
-const writeFile = pify(fs.writeFile);
-const access = pify(fs.access);
-
-// Function adapted from:
-// http://2ality.com/2015/08/es6-map-json.html#converting-a-string-map-to-and-from-an-object
-function serializeMap(stringKeyedMap) {
-  const plainObject = Object.create(null);
-  for (const pair of stringKeyedMap.entries()) {
-    const key = pair[0];
-    const value = pair[1];
-    plainObject[key] = value;
-  }
-  return JSON.stringify(plainObject);
-}
-
-// Adapted from interlock with permission:
-// https://github.com/interlockjs/interlock/blob/master/src/optimizations/file-cache/index.js
-function getCacheFilePath(opts) {
-  const canonicalPath = opts.cacheDir || tmpdir();
-
-  const initPath = opts.cacheDir
-    ? mkdirp(canonicalPath)
-    : Promise.resolve();
-
-  return initPath
-    // eslint-disable-next-line no-bitwise
-    .then(() => access(canonicalPath, fs.R_OK | fs.W_OK))
-    .then(() =>
-      path.join(
-        canonicalPath,
-        opts.scope || DEFAULT_FILENAME
-      ))
-    .catch(() => {
-      throw new Error(
-        `Unable to access cache directory.
-        Please check the directory's user permissions:
-        ${canonicalPath}`
-      );
-    });
-}
+const CREATE_TABLE_QUERY =
+  "CREATE TABLE IF NOT EXISTS cache (key TEXT PRIMARY KEY, value TEXT);";
+const GET_QUERY = "SELECT value FROM cache WHERE key IS $key;";
+const SET_QUERY = "INSERT OR REPLACE INTO cache (key, value) VALUES ($key, $value);";
 
 module.exports = class Cache {
   /**
    * Asynchronously create a new cache from disk.
    *
-   * @param   {Object} opts                  Object options
-   * @param   {Object} opts.scope            The prefix for this cache's file
-   * @param   {Object} opts.cacheDir         The directory to store cache files
-   * @returns {Promise<Cache>}               The hydrated cache
+   * @param   {Object}   opts           Object options
+   * @param   {String}   opts.filename  The filename of the SQLite database
+   * @param   {String}   opts.name      A name for this instance used in debugging
+   * @returns {Cache}                   The hydrated cache
    */
-  static init(opts) {
-    opts = opts || {};
-
-    return getCacheFilePath(opts)
-      .then(filePath => readFile(filePath, "utf8"))
-      .then(file => new Cache(opts, new Map(toPairs(JSON.parse(file)))))
-      .catch(() => new Cache(opts));
+  static create(opts = {}) {
+    const log = createDebugLogger(
+      `inspectpack:${opts.name || DEFAULT_NAME}`
+    );
+    try {
+      const db = new Database(opts.filename || DEFAULT_DATABASE);
+      // WAL mode ensures safe multiprocess access
+      db.pragma("journal_mode = WAL");
+      db.prepare(CREATE_TABLE_QUERY).run();
+      return new Cache(opts, db, log);
+    } catch (err) {
+      log("Error creating cache:", err);
+      return null;
+    }
   }
 
   /**
    * An in-memory cache that can serialize to, and deserialize from, disk.
    *
-   * @param {Object} opts                  Object options
-   * @param {Object} opts.scope            The prefix for this cache's file
-   * @param {Object} opts.cacheDir         The directory to store cache files
-   * @param {Map}    map                   An existing Map instance
+   * @param {Object}   opts           Object options
+   * @param {String}   opts.filename  The filename of the SQLite databases
+   * @param {String}   opts.name      A name for this instance used in debugging
+   * @param {Database} db             An existing SQLite database cursor
+   * @param {Function} log            A debug logger function
    */
-  constructor(opts, map) {
+  constructor(opts, db, log) {
     this._opts = opts;
-    this._cache = map || new Map();
-  }
-
-  /**
-   * Save the cache to disk.
-   *
-   * @returns {void}
-   */
-  save() {
-    return getCacheFilePath(this._opts).then(filePath =>
-      writeFile(filePath, serializeMap(this._cache)));
+    this._log = log;
+    this._db = db;
   }
 
   /**
@@ -100,7 +61,16 @@ module.exports = class Cache {
    * @returns {any}    The cached value
    */
   get(key) {
-    return this._cache.get(key) || null;
+    try {
+      const record = this._db.prepare(GET_QUERY).get({ key });
+      return flow(
+        get("value"),
+        SafeJSON.parse
+      )(record);
+    } catch (err) {
+      this._log(`Error retrieving value for key ${key}:`, err);
+      return null;
+    }
   }
 
   /**
@@ -111,6 +81,13 @@ module.exports = class Cache {
    * @returns {void}
    */
   set(key, value) {
-    this._cache.set(key, value);
+    try {
+      this._db.prepare(SET_QUERY).run({
+        key,
+        value: SafeJSON.stringify(value)
+      });
+    } catch (err) {
+      this._log(`Error setting value for key ${key}`, err, value);
+    }
   }
 };

--- a/lib/utils/cache.js
+++ b/lib/utils/cache.js
@@ -1,13 +1,11 @@
 "use strict";
 
-const createDebugLogger = require("debug");
-const { flow, get } = require("lodash/fp");
+const _ = require("lodash/fp");
 const Database = require("better-sqlite3");
 
 const SafeJSON = require("./safe-json");
 
 const DEFAULT_DATABASE = ".inspectpack-cache.db";
-const DEFAULT_NAME = "inspectpack-cache";
 
 const CREATE_TABLE_QUERY =
   "CREATE TABLE IF NOT EXISTS cache (key TEXT PRIMARY KEY, value TEXT);";
@@ -23,18 +21,16 @@ module.exports = class Cache {
    * @param   {String}   opts.name      A name for this instance used in debugging
    * @returns {Cache}                   The hydrated cache
    */
-  static create(opts = {}) {
-    const log = createDebugLogger(
-      `inspectpack:${opts.name || DEFAULT_NAME}`
-    );
+  static create(opts) {
+    opts = opts || {};
+
     try {
       const db = new Database(opts.filename || DEFAULT_DATABASE);
       // WAL mode ensures safe multiprocess access
       db.pragma("journal_mode = WAL");
       db.prepare(CREATE_TABLE_QUERY).run();
-      return new Cache(opts, db, log);
+      return new Cache(opts, db);
     } catch (err) {
-      log("Error creating cache:", err);
       return null;
     }
   }
@@ -46,11 +42,9 @@ module.exports = class Cache {
    * @param {String}   opts.filename  The filename of the SQLite databases
    * @param {String}   opts.name      A name for this instance used in debugging
    * @param {Database} db             An existing SQLite database cursor
-   * @param {Function} log            A debug logger function
    */
-  constructor(opts, db, log) {
+  constructor(opts, db) {
     this._opts = opts;
-    this._log = log;
     this._db = db;
   }
 
@@ -63,12 +57,11 @@ module.exports = class Cache {
   get(key) {
     try {
       const record = this._db.prepare(GET_QUERY).get({ key });
-      return flow(
-        get("value"),
+      return _.flow(
+        _.get("value"),
         SafeJSON.parse
       )(record);
     } catch (err) {
-      this._log(`Error retrieving value for key ${key}:`, err);
       return null;
     }
   }
@@ -87,7 +80,7 @@ module.exports = class Cache {
         value: SafeJSON.stringify(value)
       });
     } catch (err) {
-      this._log(`Error setting value for key ${key}`, err, value);
+      return;
     }
   }
 };

--- a/lib/utils/compressor.js
+++ b/lib/utils/compressor.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { tap } = require("lodash/fp");
+const tap = require("lodash/fp").tap;
 const uglify = require("uglify-es");
 const zlib = require("zlib");
 
@@ -48,8 +48,9 @@ module.exports = class Compressor {
    * @param   {Object} opts.filename The cache file to create or load
    * @returns {Promise<Compressor>}  The compressor with cache
    */
-  static create({ filename } = {}) {
-    const cache = Cache.create({ filename });
+  static create(opts) {
+    opts = opts || {};
+    const cache = Cache.create({ filename: opts.filename });
     return new Compressor(cache);
   }
 

--- a/lib/utils/compressor.js
+++ b/lib/utils/compressor.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const { tap } = require("lodash/fp");
 const uglify = require("uglify-es");
 const zlib = require("zlib");
 
@@ -44,16 +45,12 @@ module.exports = class Compressor {
    * Start the compressor with an asynchronously initialized cache.
    *
    * @param   {Object} opts          Object options
-   * @param   {Object} opts.cacheDir The directory to store cache files in
+   * @param   {Object} opts.filename The cache file to create or load
    * @returns {Promise<Compressor>}  The compressor with cache
    */
-  static init(opts) {
-    opts = opts || {};
-
-    return Cache.init({
-      scope: opts.scope,
-      cacheDir: opts.cacheDir
-    }).then(cache => new Compressor(cache));
+  static create({ filename } = {}) {
+    const cache = Cache.create({ filename });
+    return new Compressor(cache);
   }
 
   /**
@@ -64,17 +61,6 @@ module.exports = class Compressor {
    */
   constructor(cache) {
     this._cache = cache || null;
-  }
-
-  /**
-   * Save the compressor's cache to disk.
-   *
-   * @returns {void}
-   */
-  saveCache() {
-    if (this._cache) {
-      this._cache.save();
-    }
   }
 
   /**
@@ -89,15 +75,24 @@ module.exports = class Compressor {
    * @returns {Promise<Object>} The aggregated code size statistics
    */
   getSizes(opts) {
-    const hashedKey = hash(opts);
-
-    if (this._cache) {
-      const cachedValue = this._cache.get(hashedKey);
-      if (cachedValue) {
-        return Promise.resolve(cachedValue);
-      }
+    if (!this._cache) {
+      return this._calculateSizes(opts);
     }
 
+    const hashedKey = hash(opts);
+
+    const cachedValue = this._cache.get(hashedKey);
+    if (cachedValue) {
+      return Promise.resolve(cachedValue);
+    }
+
+    return this._calculateSizes(opts)
+      .then(tap(fullSizes =>
+        this._cache.set(hashedKey, fullSizes))
+      );
+  }
+
+  _calculateSizes(opts) {
     const sizes = {
       full: opts.source.length,
       min: "--",
@@ -128,13 +123,6 @@ module.exports = class Compressor {
             min: result.code.length,
             minGz
           }));
-      })
-      .then(fullSizes => {
-        if (this._cache) {
-          this._cache.set(hashedKey, fullSizes);
-          this._cache.save();
-        }
-        return fullSizes;
       });
   }
 };

--- a/lib/utils/safe-json.js
+++ b/lib/utils/safe-json.js
@@ -1,0 +1,19 @@
+"use strict";
+
+module.exports = class SafeJSON {
+  static parse(string) {
+    try {
+      return JSON.parse(string);
+    } catch (err) {
+      return null;
+    }
+  }
+
+  static stringify(object) {
+    try {
+      return JSON.stringify(object);
+    } catch (err) {
+      return null;
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "babel-types": "^6.7.2",
     "babylon": "^6.7.0",
     "better-sqlite3": "^4.0.2",
-    "debug": "^3.0.1",
     "lodash": "^4.6.1",
     "pify": "^2.3.0",
     "uglify-es": "^3.0.28",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "better-sqlite3": "^4.0.2",
     "debug": "^3.0.1",
     "lodash": "^4.6.1",
-    "mkdirp": "^0.5.1",
     "pify": "^2.3.0",
     "uglify-es": "^3.0.28",
     "workerpool": "^2.2.1",
@@ -52,6 +51,8 @@
     "eslint-plugin-lodash-fp": "^2.1.3",
     "formidable-playbook": "^0.1.0",
     "inspectpack-test-fixtures": "^1.2.0",
-    "mocha": "^3.2.0"
+    "mkdirp": "^0.5.1",
+    "mocha": "^3.2.0",
+    "rimraf": "^2.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "babel-traverse": "^6.7.6",
     "babel-types": "^6.7.2",
     "babylon": "^6.7.0",
+    "better-sqlite3": "^4.0.2",
+    "debug": "^3.0.1",
     "lodash": "^4.6.1",
     "mkdirp": "^0.5.1",
     "pify": "^2.3.0",

--- a/test/smoke.spec.js
+++ b/test/smoke.spec.js
@@ -21,7 +21,7 @@ const readFile = (relPath) => fs.readFileSync(path.join(fixtureRoot, relPath), "
 const basicFixture = readFile("built/basic-lodash-object-expression.js");
 const badBundleFixture = readFile("dist/bad-bundle.js");
 
-const testOutputDir = path.join(process.cwd(), "test-output");
+const testOutputDir = path.resolve("test-output");
 
 const finishAsserts = require("./util").finishAsserts;
 
@@ -163,7 +163,7 @@ describe("Smoke tests", () => {
 
   describe("daemon", () => {
     beforeEach(() => mkdirp(testOutputDir));
-    afterEach(() => rimraf.sync(testOutputDir));
+    afterEach(done => rimraf(testOutputDir, done));
 
     it("runs actions in the daemon with a cache", () => {
       const NS_PER_SEC = 1e9;
@@ -186,8 +186,8 @@ describe("Smoke tests", () => {
         minified: false,
         gzip: false
       }).then(() => {
-        const [seconds, nanoseconds] = process.hrtime(coldStart);
-        coldTime = seconds * NS_PER_SEC + nanoseconds;
+        const time = process.hrtime(coldStart);
+        coldTime = time[0] * NS_PER_SEC + time[1];
         hotStart = process.hrtime();
         return daemon.sizes({
           code: badBundleFixture,
@@ -196,8 +196,8 @@ describe("Smoke tests", () => {
           gzip: false
         });
       }).then(() => {
-        const [seconds, nanoseconds] = process.hrtime(hotStart);
-        hotTime = seconds * NS_PER_SEC + nanoseconds;
+        const time = process.hrtime(hotStart);
+        hotTime = time[0] * NS_PER_SEC + time[1];
 
         // Fail if the hot run isn't way faster than the cold run.
         // This indicates that the cache is failing.

--- a/yarn.lock
+++ b/yarn.lock
@@ -251,6 +251,15 @@ benchmark@^2.1.4:
     lodash "^4.17.4"
     platform "^1.3.3"
 
+better-sqlite3@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-4.0.2.tgz#3a5542252e199ffcc3a58116255a39882fe06eeb"
+  dependencies:
+    bindings "^1.2.1"
+    integer "^1.0.1"
+    lzz-gyp "^0.3.5"
+    to-descriptor "^1.0.1"
+
 big.js@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
@@ -258,6 +267,10 @@ big.js@^3.1.3:
 binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
+
+bindings@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
 
 block-stream@*:
   version "0.0.9"
@@ -610,6 +623,12 @@ debug@^2.1.1, debug@^2.2.0:
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:
     ms "0.7.2"
+
+debug@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.0.1.tgz#0564c612b521dc92d9f2988f0549e34f9c98db64"
+  dependencies:
+    ms "2.0.0"
 
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
@@ -1325,6 +1344,12 @@ inspectpack-test-fixtures@^1.2.0:
     old-lodash "1.0.1"
     webpack "2.3.3"
 
+integer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/integer/-/integer-1.0.1.tgz#41ecb5db9931c1a069728f4764f8d7eeee02b249"
+  dependencies:
+    bindings "^1.2.1"
+
 interpret@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
@@ -1671,6 +1696,10 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0"
 
+lzz-gyp@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/lzz-gyp/-/lzz-gyp-0.3.5.tgz#0ec67d00f4bdaa5bc5c5eecd1eb3beed181032e5"
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -1769,11 +1798,15 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
 mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
-nan@^2.3.0, nan@^2.4.0:
+nan@^2.3.0, nan@^2.4.0, nan@~2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
 
@@ -1812,6 +1845,20 @@ node-libs-browser@^2.0.0:
 node-pre-gyp@^0.6.29:
   version "0.6.34"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.34.tgz#94ad1c798a11d7fc67381b50d47f8cc18d9799f7"
+  dependencies:
+    mkdirp "^0.5.1"
+    nopt "^4.0.1"
+    npmlog "^4.0.2"
+    rc "^1.1.7"
+    request "^2.81.0"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^2.2.1"
+    tar-pack "^3.4.0"
+
+node-pre-gyp@~0.6.36:
+  version "0.6.36"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz#db604112cb74e0d477554e9b505b17abddfab786"
   dependencies:
     mkdirp "^0.5.1"
     nopt "^4.0.1"
@@ -2338,6 +2385,19 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
+sqlite3@^3.1.8:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-3.1.9.tgz#b2e7fbaa348380318d3834323918c3c351b8bf18"
+  dependencies:
+    nan "~2.6.2"
+    node-pre-gyp "~0.6.36"
+
+sqlite@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/sqlite/-/sqlite-2.8.0.tgz#acb6d1869a5241c57016c88606eca009f0f31b90"
+  dependencies:
+    sqlite3 "^3.1.8"
+
 sshpk@^1.7.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.0.tgz#ff2a3e4fd04497555fed97b39a0fd82fafb3a33c"
@@ -2483,6 +2543,10 @@ to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
 
+to-descriptor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/to-descriptor/-/to-descriptor-1.0.1.tgz#a0e678c34ebc7d2dae464d8372bc21479d9c2bcd"
+
 to-fast-properties@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
@@ -2536,7 +2600,7 @@ uglify-es@^3.0.28:
     commander "~2.11.0"
     source-map "~0.5.1"
 
-uglify-js@^2.6.2, uglify-js@^2.8.5:
+uglify-js@^2.8.5:
   version "2.8.22"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.22.tgz#d54934778a8da14903fa29a326fb24c0ab51a1a0"
   dependencies:


### PR DESCRIPTION
This PR replaces the custom `Map`/file cache with a simple SQLite integration. This gives us a few things:

- No more overflushing to disk/indecision over when to flush to disk.
- It's safe to write concurrently to a SQLite database ([when in WAL mode](https://sqlite.org/wal.html)). This means we can use more than one worker–the worker pool now matches the number of CPUs.

Parallelizing the sizes and problems actions seems to boost performance around 2x, although I haven't measured it yet.

Breaking changes: the async class factories previously named `init` are now synchronous and named `create`.