### PR TITLE
Optional cache + refactor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ coverage
 Procfile
 .lankrc*
 test-output
+package-lock.json

--- a/lib/daemon/index.js
+++ b/lib/daemon/index.js
@@ -1,12 +1,10 @@
 "use strict";
 
-const tap = require("lodash/fp").tap;
 const cpus = require("os").cpus;
 const path = require("path");
 const workerpool = require("workerpool");
 
 const actions = require("../actions");
-const hash = require("../utils/hash");
 
 class InspectpackDaemon {
   /**
@@ -54,16 +52,10 @@ class InspectpackDaemon {
 // The generated methods look like `daemon.sizes(...).then(...)`
 Object.keys(actions.ACTIONS).forEach((action) => {
   InspectpackDaemon.prototype[action] = function (opts) {
-    const hashedKey = hash({ action, opts });
-    const cachedValue = this._cache.get(hashedKey);
-    if (cachedValue) {
-      return Promise.resolve(cachedValue);
-    }
-
-    return this._pool.exec(action, [opts])
-      .then(tap((result) =>
-        this._cache.set(hashedKey, result)
-      ));
+    return this._cache.wrapAction({
+      hashArgs: (args) => ({ action, args }),
+      action: (args) => this._pool.exec(action, [args])
+    })(opts);
   };
 });
 

--- a/lib/daemon/index.js
+++ b/lib/daemon/index.js
@@ -11,9 +11,10 @@ class InspectpackDaemon {
   /**
    * Start the daemon with an asynchronously initialized cache.
    *
-   * @param {Object} opts                  Object options
-   * @param {Object} opts.cache            A cache instance
-   * @returns {InspectpackDaemon} The daemon with cache
+   * @param {Object} opts                 Object options
+   * @param {Object} opts.cache           A cache instance
+   * @param {Object} opts.cacheFilename   A filename to create a cache if not provided.
+   * @returns {InspectpackDaemon}         The daemon with cache
    */
   static create(opts) {
     return new InspectpackDaemon(opts);

--- a/lib/daemon/index.js
+++ b/lib/daemon/index.js
@@ -5,6 +5,7 @@ const path = require("path");
 const workerpool = require("workerpool");
 
 const actions = require("../actions");
+const Cache = require("../utils/cache");
 
 class InspectpackDaemon {
   /**
@@ -21,12 +22,15 @@ class InspectpackDaemon {
   /**
    * Start the daemon with either no cache or an existing cache.
    *
-   * @param {Object} opts                  Object options
-   * @param {Object} opts.cache            A cache instance
-   * @returns {InspectpackDaemon} The daemon with cache
+   * @param {Object} opts                 Object options
+   * @param {Object} opts.cache           A cache instance
+   * @param {Object} opts.cacheFilename   A filename to create a cache if not provided.
+   * @returns {InspectpackDaemon}         The daemon with cache
    */
   constructor(opts) {
-    this._cache = (opts || {}).cache;
+    opts = opts || {};
+    this._cache = opts.cache ||
+      (opts.cacheFilename ? Cache.create({ filename: opts.cacheFilename }) : null);
     if (!this._cache) {
       throw new Error("Cache is required");
     }

--- a/lib/daemon/index.js
+++ b/lib/daemon/index.js
@@ -14,29 +14,28 @@ class InspectpackDaemon {
    * Start the daemon with an asynchronously initialized cache.
    *
    * @param {Object} opts                  Object options
+   * @param {Object} opts.cache            A cache instance
    * @param {Object} opts.cacheFilename    The filename of the daemon cache
    * @returns {InspectpackDaemon} The daemon with cache
    */
   static create(opts) {
     opts = opts || {};
-    const cache = Cache.create({ filename: opts.cacheFilename });
+    const cache = opts.cache || Cache.create({ filename: opts.cacheFilename });
     return new InspectpackDaemon(cache, opts);
   }
 
   /**
    * Start the daemon with either no cache or an existing cache.
    *
-   * @param {Cache} cache                  An existing cache instance
-   * @param {Object} opts                  Object options
-   * @param {Object} opts.cacheFilename    The filename of the daemon cache
+   * @param {Cache} cache                  A cache instance
    */
-  constructor(cache, opts) {
+  constructor(cache) {
     this._cache = cache || null;
-    this._cacheFilename = opts.cacheFilename || null;
+    const cacheFilename = this._cache && this._cache.filename;
     this._pool = workerpool.pool(path.resolve(__dirname, "worker.js"), {
       minWorkers: cpus().length,
       maxWorkers: cpus().length,
-      forkArgs: [`cacheFilename=${this._cacheFilename}`]
+      forkArgs: cacheFilename ? [`cacheFilename=${cacheFilename}`] : []
     });
   }
 
@@ -54,10 +53,6 @@ class InspectpackDaemon {
 // The generated methods look like `daemon.sizes(...).then(...)`
 Object.keys(actions.ACTIONS).forEach((action) => {
   InspectpackDaemon.prototype[action] = function (opts) {
-    if (!this._cache) {
-      return this._pool.exec(action, [opts]);
-    }
-
     const hashedKey = hash({ action, opts });
     const cachedValue = this._cache.get(hashedKey);
     if (cachedValue) {

--- a/lib/daemon/index.js
+++ b/lib/daemon/index.js
@@ -6,7 +6,6 @@ const path = require("path");
 const workerpool = require("workerpool");
 
 const actions = require("../actions");
-const Cache = require("../utils/cache");
 const hash = require("../utils/hash");
 
 class InspectpackDaemon {
@@ -15,27 +14,29 @@ class InspectpackDaemon {
    *
    * @param {Object} opts                  Object options
    * @param {Object} opts.cache            A cache instance
-   * @param {Object} opts.cacheFilename    The filename of the daemon cache
    * @returns {InspectpackDaemon} The daemon with cache
    */
   static create(opts) {
-    opts = opts || {};
-    const cache = opts.cache || Cache.create({ filename: opts.cacheFilename });
-    return new InspectpackDaemon(cache, opts);
+    return new InspectpackDaemon(opts);
   }
 
   /**
    * Start the daemon with either no cache or an existing cache.
    *
-   * @param {Cache} cache                  A cache instance
+   * @param {Object} opts                  Object options
+   * @param {Object} opts.cache            A cache instance
+   * @returns {InspectpackDaemon} The daemon with cache
    */
-  constructor(cache) {
-    this._cache = cache || null;
-    const cacheFilename = this._cache && this._cache.filename;
+  constructor(opts) {
+    this._cache = (opts || {}).cache;
+    if (!this._cache) {
+      throw new Error("Cache is required");
+    }
+
     this._pool = workerpool.pool(path.resolve(__dirname, "worker.js"), {
       minWorkers: cpus().length,
       maxWorkers: cpus().length,
-      forkArgs: cacheFilename ? [`cacheFilename=${cacheFilename}`] : []
+      forkArgs: this._cache ? [JSON.stringify({ cache: this._cache.serialize() })] : []
     });
   }
 

--- a/lib/daemon/index.js
+++ b/lib/daemon/index.js
@@ -48,7 +48,6 @@ class InspectpackDaemon {
       .exec(action, optsArr)
       .catch((err) => {
         console.error("Worker error", err); // eslint-disable-line no-console
-        this.terminate();
       });
   }
 

--- a/lib/daemon/index.js
+++ b/lib/daemon/index.js
@@ -42,6 +42,15 @@ class InspectpackDaemon {
     });
   }
 
+  exec(action, optsArr) {
+    return this._pool
+      .exec(action, optsArr)
+      .catch((err) => {
+        console.error("Worker error", err); // eslint-disable-line no-console
+        this.terminate();
+      });
+  }
+
   /**
    * Terminate the daemon.
    *
@@ -58,7 +67,7 @@ Object.keys(actions.ACTIONS).forEach((action) => {
   InspectpackDaemon.prototype[action] = function (opts) {
     return this._cache.wrapAction({
       hashArgs: (args) => ({ action, args }),
-      action: (args) => this._pool.exec(action, [args])
+      action: (args) => this.exec(action, [args])
     })(opts);
   };
 });

--- a/lib/daemon/worker.js
+++ b/lib/daemon/worker.js
@@ -21,12 +21,7 @@ const wrapMethod = (action, compressor) => (args) =>
   new Promise((resolve, reject) =>
     actions(action)(
       Object.assign({}, args, { compressor }),
-      (err, result) => {
-        if (err) {
-          return reject(err);
-        }
-        return resolve(result);
-      }
+      (err, result) => err ? reject(err) : resolve(result)
     ));
 
 // Create each action method, injecting a compressor

--- a/lib/daemon/worker.js
+++ b/lib/daemon/worker.js
@@ -10,6 +10,8 @@ const cacheFilenameArg = process.argv
 const filename = cacheFilenameArg && cacheFilenameArg
   .replace("cacheFilename=", "");
 
+console.log("TODO HERE", { filename })
+
 // Create worker methods for each corresponding action.
 // The generated methods look like `sizes(...).then(...)`
 const wrapMethod = (action, compressor) => (args) =>

--- a/lib/daemon/worker.js
+++ b/lib/daemon/worker.js
@@ -4,13 +4,16 @@ const workerpool = require("workerpool");
 
 const actions = require("../actions");
 const Compressor = require("../utils/compressor");
+const SafeJSON = require("../utils/safe-json");
+const Cache = require("../utils/cache");
 
-const cacheFilenameArg = process.argv
-  .find((arg) => arg.indexOf("cacheFilename=") !== -1);
-const filename = cacheFilenameArg && cacheFilenameArg
-  .replace("cacheFilename=", "");
-
-console.log("TODO HERE", { filename })
+// Deserialize options and inflate needed objects.
+const INFLATE_ARGS_IDX = 2;
+const inflated = SafeJSON.parse(process.argv[INFLATE_ARGS_IDX]) || {};
+const cacheOpts = inflated.cache || {};
+const cacheCls = cacheOpts.cls || Cache.NoopCache.name;
+delete cacheOpts.cls;
+const cache = Cache[cacheCls].create(cacheOpts);
 
 // Create worker methods for each corresponding action.
 // The generated methods look like `sizes(...).then(...)`
@@ -33,7 +36,7 @@ workerpool.worker(
     (acc, action) => Object.assign({}, acc, {
       [action]: wrapMethod(
         action,
-        Compressor.create({ filename })
+        Compressor.create({ cache })
       )
     }),
     {}

--- a/lib/models/bundle.js
+++ b/lib/models/bundle.js
@@ -272,19 +272,24 @@ Bundle.create = function (opts, callback) {
   if (opts.code) {
     // Prevent Zalgo by executing on the next tick.
     return setImmediate(() => {
-      const bundle = new Bundle({
-        code: opts.code,
-        allowEmpty: opts.allowEmpty
-      });
-
-      let err = null;
+      let bundle;
       try {
-        bundle.validate();
-      } catch (validateErr) {
-        err = validateErr;
+        bundle = new Bundle({
+          code: opts.code,
+          allowEmpty: opts.allowEmpty
+        });
+      } catch (err) {
+        err.message = `${(err.message || "")} (source code: ${opts.code.toString()})`;
+        return void callback(err);
       }
 
-      callback(err, bundle);
+      try {
+        bundle.validate();
+      } catch (err) {
+        return void callback(err);
+      }
+
+      callback(null, bundle);
     });
   }
 
@@ -293,20 +298,25 @@ Bundle.create = function (opts, callback) {
       return void callback(readErr);
     }
 
-    // Create and validate.
-    const bundle = new Bundle({
-      path: opts.bundle,
-      code: data.toString(),
-      allowEmpty: opts.allowEmpty
-    });
-
-    let err = null;
+    let bundle;
     try {
-      bundle.validate();
-    } catch (validateErr) {
-      err = validateErr;
+      bundle = new Bundle({
+        path: opts.bundle,
+        code: data.toString(),
+        allowEmpty: opts.allowEmpty
+      });
+    } catch (err) {
+      err.message = `${(err.message || "")} ` +
+        `(source code: ${opts.code.toString()}, bundle path: ${opts.bundle})`;
+      return void callback(err);
     }
 
-    callback(err, bundle);
+    try {
+      bundle.validate();
+    } catch (err) {
+      return void callback(err);
+    }
+
+    callback(null, bundle);
   });
 };

--- a/lib/models/bundle.js
+++ b/lib/models/bundle.js
@@ -246,6 +246,27 @@ Bundle.prototype._validateGroups = function () {
   });
 };
 
+// Internal helper
+const createBundle = (opts, callback) => {
+  let bundle;
+  try {
+    bundle = new Bundle(opts);
+  } catch (err) {
+    err.message = `${(err.message || "")} ` +
+      `(source code: ${opts.code.toString()}` +
+      `${opts.bundle ? `, bundle path: ${opts.bundle}` : ""})`;
+    return void callback(err);
+  }
+
+  try {
+    bundle.validate();
+  } catch (err) {
+    return void callback(err);
+  }
+
+  callback(null, bundle);
+};
+
 /**
  * Create and validate bundle object from file.
  *
@@ -253,10 +274,11 @@ Bundle.prototype._validateGroups = function () {
  * - `output.pathinfo = true`
  * - No minification.
  *
- * @param {Object}    opts        Options
- * @param {String}    opts.bundle Path to bundle file
- * @param {String}    opts.code   A raw string of a bundle
- * @param {Function}  callback    Form `(err, data)`
+ * @param {Object}    opts              Options
+ * @param {String}    opts.bundle       Path to bundle file
+ * @param {String}    opts.code         A raw string of a bundle
+ * @param {Boolean}   opts.allowEmpty   Allow empty bundle?
+ * @param {Function}  callback          Form `(err, data)`
  * @returns {void}
  */
 Bundle.create = function (opts, callback) {
@@ -272,24 +294,10 @@ Bundle.create = function (opts, callback) {
   if (opts.code) {
     // Prevent Zalgo by executing on the next tick.
     return setImmediate(() => {
-      let bundle;
-      try {
-        bundle = new Bundle({
-          code: opts.code,
-          allowEmpty: opts.allowEmpty
-        });
-      } catch (err) {
-        err.message = `${(err.message || "")} (source code: ${opts.code.toString()})`;
-        return void callback(err);
-      }
-
-      try {
-        bundle.validate();
-      } catch (err) {
-        return void callback(err);
-      }
-
-      callback(null, bundle);
+      createBundle({
+        code: opts.code,
+        allowEmpty: opts.allowEmpty
+      }, callback);
     });
   }
 
@@ -298,25 +306,10 @@ Bundle.create = function (opts, callback) {
       return void callback(readErr);
     }
 
-    let bundle;
-    try {
-      bundle = new Bundle({
-        path: opts.bundle,
-        code: data.toString(),
-        allowEmpty: opts.allowEmpty
-      });
-    } catch (err) {
-      err.message = `${(err.message || "")} ` +
-        `(source code: ${opts.code.toString()}, bundle path: ${opts.bundle})`;
-      return void callback(err);
-    }
-
-    try {
-      bundle.validate();
-    } catch (err) {
-      return void callback(err);
-    }
-
-    callback(null, bundle);
+    createBundle({
+      path: opts.bundle,
+      code: data.toString(),
+      allowEmpty: opts.allowEmpty
+    }, callback);
   });
 };

--- a/lib/utils/cache.js
+++ b/lib/utils/cache.js
@@ -17,44 +17,46 @@ const SET_QUERY = "INSERT OR REPLACE INTO cache (key, value) VALUES ($key, $valu
 
 class NoopCache {
   static create() { return new NoopCache(); }
+  serialize() { return { cls: NoopCache.name }; }
   get() { return null; }
   set() {}
 }
 
 class SqliteCache {
   /**
-   * Asynchronously create a new cache from disk.
+   * Create a new cache from disk.
    *
    * @param   {Object}   opts           Object options
    * @param   {String}   opts.filename  The filename of the SQLite database
-   * @param   {String}   opts.name      A name for this instance used in debugging
    * @returns {Cache}                   The hydrated cache or noop cache on error
    */
   static create(opts) {
-    opts = opts || {};
-
     try {
-      const db = new Database(opts.filename || DEFAULT_DATABASE);
-      // WAL mode ensures safe multiprocess access
-      db.pragma("journal_mode = WAL");
-      db.prepare(CREATE_TABLE_QUERY).run();
-      return new SqliteCache(opts, db);
+      return new SqliteCache(opts);
     } catch (err) {
       return new NoopCache();
     }
   }
 
   /**
-   * An in-memory cache that can serialize to, and deserialize from, disk.
+   * A cache that can serialize to, and deserialize from, disk.
    *
    * @param {Object}   opts           Object options
    * @param {String}   opts.filename  The filename of the SQLite databases
-   * @param {String}   opts.name      A name for this instance used in debugging
-   * @param {Database} db             An existing SQLite database cursor
    */
-  constructor(opts, db) {
-    this._opts = opts;
-    this._db = db;
+  constructor(opts) {
+    this._filename = (opts || {}).filename || DEFAULT_DATABASE;
+    this._db = new Database(this._filename);
+    // WAL mode ensures safe multiprocess access
+    this._db.pragma("journal_mode = WAL");
+    this._db.prepare(CREATE_TABLE_QUERY).run();
+  }
+
+  serialize() {
+    return {
+      cls: SqliteCache.name,
+      filename: this._filename
+    };
   }
 
   /**
@@ -88,9 +90,7 @@ class SqliteCache {
         key,
         value: SafeJSON.stringify(value)
       });
-    } catch (err) {
-      return;
-    }
+    } catch (err) { /* passthrough */ }
   }
 }
 
@@ -98,7 +98,7 @@ class SqliteCache {
 module.exports = Database ? SqliteCache : NoopCache;
 
 // Attach classes for testing.
-module.exports._classes = {
+Object.assign(module.exports, {
   SqliteCache,
   NoopCache
-};
+});

--- a/lib/utils/cache.js
+++ b/lib/utils/cache.js
@@ -1,12 +1,14 @@
 "use strict";
 /*eslint-disable lodash-fp/prefer-constant*/
 
-const _ = require("lodash/fp");
+const tap = require("lodash/fp").tap;
+
 let Database;
 try {
   Database = require("better-sqlite3"); // eslint-disable-line global-require
 } catch (err) { /* passthrough */ }
 
+const hash = require("./hash");
 const SafeJSON = require("./safe-json");
 
 const DEFAULT_DATABASE = ".inspectpack-cache.db";
@@ -18,8 +20,9 @@ const SET_QUERY = "INSERT OR REPLACE INTO cache (key, value) VALUES ($key, $valu
 class NoopCache {
   static create() { return new NoopCache(); }
   serialize() { return { cls: NoopCache.name }; }
-  get() { return null; }
+  get() {return null; }
   set() {}
+  wrapAction(opts) { return opts.action; }
 }
 
 class SqliteCache {
@@ -68,10 +71,7 @@ class SqliteCache {
   get(key) {
     try {
       const record = this._db.prepare(GET_QUERY).get({ key });
-      return _.flow(
-        _.get("value"),
-        SafeJSON.parse
-      )(record);
+      return SafeJSON.parse((record || {}).value);
     } catch (err) {
       return null;
     }
@@ -91,6 +91,30 @@ class SqliteCache {
         value: SafeJSON.stringify(value)
       });
     } catch (err) { /* passthrough */ }
+  }
+
+  /**
+   * Retrieve a value from the cache by key.
+   *
+   * @param   {Object}   opts           Options object.
+   * @param   {Function} opts.action    Raw function to invoke (returns promise).
+   * @param   {Function} opts.hashArgs  Optional hash argument function.
+   * @returns {Function}                Wrapped action with cache get/set.
+   */
+  wrapAction(opts) {
+    return (args) => {
+      const hashedKey = hash(opts.hashArgs ? opts.hashArgs(args) : args);
+
+      const cachedValue = this.get(hashedKey);
+      if (cachedValue) {
+        return Promise.resolve(cachedValue);
+      }
+
+      return opts.action(args)
+        .then(tap((value) =>
+          this.set(hashedKey, value))
+        );
+    };
   }
 }
 

--- a/lib/utils/cache.js
+++ b/lib/utils/cache.js
@@ -20,7 +20,7 @@ const SET_QUERY = "INSERT OR REPLACE INTO cache (key, value) VALUES ($key, $valu
 class NoopCache {
   static create() { return new NoopCache(); }
   serialize() { return { cls: NoopCache.name }; }
-  get() {return null; }
+  get() { return null; }
   set() {}
   wrapAction(opts) { return opts.action; }
 }

--- a/lib/utils/cache.js
+++ b/lib/utils/cache.js
@@ -1,25 +1,34 @@
 "use strict";
+/*eslint-disable lodash-fp/prefer-constant*/
 
 const _ = require("lodash/fp");
-const Database = require("better-sqlite3");
+let Database;
+try {
+  Database = require("better-sqlite3"); // eslint-disable-line global-require
+} catch (err) { /* passthrough */ }
 
 const SafeJSON = require("./safe-json");
 
 const DEFAULT_DATABASE = ".inspectpack-cache.db";
 
-const CREATE_TABLE_QUERY =
-  "CREATE TABLE IF NOT EXISTS cache (key TEXT PRIMARY KEY, value TEXT);";
+const CREATE_TABLE_QUERY = "CREATE TABLE IF NOT EXISTS cache (key TEXT PRIMARY KEY, value TEXT);";
 const GET_QUERY = "SELECT value FROM cache WHERE key IS $key;";
 const SET_QUERY = "INSERT OR REPLACE INTO cache (key, value) VALUES ($key, $value);";
 
-module.exports = class Cache {
+class NoopCache {
+  static create() { return new NoopCache(); }
+  get() { return null; }
+  set() {}
+}
+
+class SqliteCache {
   /**
    * Asynchronously create a new cache from disk.
    *
    * @param   {Object}   opts           Object options
    * @param   {String}   opts.filename  The filename of the SQLite database
    * @param   {String}   opts.name      A name for this instance used in debugging
-   * @returns {Cache}                   The hydrated cache
+   * @returns {Cache}                   The hydrated cache or noop cache on error
    */
   static create(opts) {
     opts = opts || {};
@@ -29,9 +38,9 @@ module.exports = class Cache {
       // WAL mode ensures safe multiprocess access
       db.pragma("journal_mode = WAL");
       db.prepare(CREATE_TABLE_QUERY).run();
-      return new Cache(opts, db);
+      return new SqliteCache(opts, db);
     } catch (err) {
-      return null;
+      return new NoopCache();
     }
   }
 
@@ -83,4 +92,13 @@ module.exports = class Cache {
       return;
     }
   }
+}
+
+// Export appropriate cache class.
+module.exports = Database ? SqliteCache : NoopCache;
+
+// Attach classes for testing.
+module.exports._classes = {
+  SqliteCache,
+  NoopCache
 };

--- a/lib/utils/compressor.js
+++ b/lib/utils/compressor.js
@@ -1,11 +1,9 @@
 "use strict";
 
-const tap = require("lodash/fp").tap;
 const uglify = require("uglify-es");
 const zlib = require("zlib");
 
 const Cache = require("./cache");
-const hash = require("./hash");
 
 const DEFAULT_UGLIFY_OPTS = {
   warnings: false,
@@ -70,17 +68,9 @@ module.exports = class Compressor {
    * @returns {Promise<Object>} The aggregated code size statistics
    */
   getSizes(opts) {
-    const hashedKey = hash(opts);
-
-    const cachedValue = this._cache.get(hashedKey);
-    if (cachedValue) {
-      return Promise.resolve(cachedValue);
-    }
-
-    return this._calculateSizes(opts)
-      .then(tap((fullSizes) =>
-        this._cache.set(hashedKey, fullSizes))
-      );
+    return this._cache.wrapAction({
+      action: this._calculateSizes.bind(this)
+    })(opts);
   }
 
   _calculateSizes(opts) {

--- a/lib/utils/compressor.js
+++ b/lib/utils/compressor.js
@@ -42,27 +42,25 @@ const getMinifiedLength = (opts) =>
 
 module.exports = class Compressor {
   /**
-   * Start the compressor with an asynchronously initialized cache.
+   * Start the compressor with a cache.
    *
-   * @param   {Object} opts          Object options
-   * @param   {Object} opts.filename The cache file to create or load
-   * @returns {Promise<Compressor>}  The compressor with cache
+   * @param   {Object} opts         Object options
+   * @param   {Object} opts.cache   Cache instance
+   * @returns {Compressor}          The compressor with cache
    */
   static create(opts) {
-    opts = opts || {};
-    console.log("TODO HERE COMPRESSOR", opts);
-    const cache = Cache.create({ filename: opts.filename });
-    return new Compressor(cache);
+    return new Compressor(opts);
   }
 
   /**
    * A centralized manager for uglifying, gzipping, and retrieving file sizes.
    *
-   * @param   {Cache} cache An existing cache instance
+   * @param   {Object} opts          Object options
+   * @param   {Object} opts.cache    Cache instance
    * @returns {void}
    */
-  constructor(cache) {
-    this._cache = cache || null;
+  constructor(opts) {
+    this._cache = (opts || {}).cache || Cache.NoopCache.create();
   }
 
   /**
@@ -77,10 +75,6 @@ module.exports = class Compressor {
    * @returns {Promise<Object>} The aggregated code size statistics
    */
   getSizes(opts) {
-    if (!this._cache) {
-      return this._calculateSizes(opts);
-    }
-
     const hashedKey = hash(opts);
 
     const cachedValue = this._cache.get(hashedKey);

--- a/lib/utils/compressor.js
+++ b/lib/utils/compressor.js
@@ -50,6 +50,7 @@ module.exports = class Compressor {
    */
   static create(opts) {
     opts = opts || {};
+    console.log("TODO HERE COMPRESSOR", opts);
     const cache = Cache.create({ filename: opts.filename });
     return new Compressor(cache);
   }

--- a/lib/utils/compressor.js
+++ b/lib/utils/compressor.js
@@ -22,12 +22,7 @@ const gzip = (opts) =>
     zlib.gzip(
       opts.source,
       opts.gzipOpts || DEFAULT_GZIP_OPTS,
-      (err, buffer) => {
-        if (err) {
-          return reject(err);
-        }
-        return resolve(buffer);
-      }
+      (err, buffer) => err ? reject(err) : resolve(buffer)
     ));
 
 const minify = (opts) =>

--- a/lib/utils/hash.js
+++ b/lib/utils/hash.js
@@ -4,15 +4,11 @@ const crypto = require("crypto");
 
 let farmhash;
 try {
-  // eslint-disable-next-line global-require
-  farmhash = require("farmhash");
-} catch (err) {
-  farmhash = null;
-}
+  farmhash = require("farmhash"); // eslint-disable-line global-require
+} catch (err) { /* passthrough */ }
 
 module.exports = function (item) {
-  const hashee = typeof item === "string"
-    ? item : JSON.stringify(item);
+  const hashee = typeof item === "string" ? item : JSON.stringify(item);
 
   return farmhash
     ? farmhash.hash64(hashee)

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
   "dependencies": {
     "babel-types": "^6.7.2",
     "babylon": "^6.7.0",
-    "better-sqlite3": "^4.0.2",
     "lodash": "^4.6.1",
     "uglify-es": "^3.0.28",
     "workerpool": "^2.2.1",
     "yargs": "^4.3.1"
   },
   "optionalDependencies": {
+    "better-sqlite3": "^4.0.2",
     "farmhash": "^1.2.1"
   },
   "devDependencies": {
@@ -51,6 +51,8 @@
     "mkdirp": "^0.5.1",
     "mocha": "^3.2.0",
     "pify": "^3.0.0",
-    "rimraf": "^2.6.1"
+    "rimraf": "^2.6.1",
+    "sinon": "^4.0.0",
+    "sinon-chai": "^2.13.0"
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -8,8 +8,6 @@ plugins:
   - lodash-fp
 
 rules:
-  func-style: off
-  arrow-parens: off
   no-magic-numbers: off
   no-unused-expressions: off
   max-nested-callbacks: off

--- a/test/lib/utils/compressor.spec.js
+++ b/test/lib/utils/compressor.spec.js
@@ -28,21 +28,21 @@ describe("lib/utils/compressor", () => {
       const comp = create();
 
       return Promise.all([
-        comp.getSizes({ source: "" }).then(sizes => {
+        comp.getSizes({ source: "" }).then((sizes) => {
           expect(sizes).to.eql(EMPTY_SIZES);
         }),
 
-        comp.getSizes({ source: "", minified: true, gzip: true }).then(sizes => {
+        comp.getSizes({ source: "", minified: true, gzip: true }).then((sizes) => {
           expect(sizes).to.eql(EMPTY_SIZES_GZ);
         }),
 
-        comp.getSizes({ source: "    " }).then(sizes => {
+        comp.getSizes({ source: "    " }).then((sizes) => {
           expect(sizes).to.eql(Object.assign({}, EMPTY_SIZES, {
             full: 4
           }));
         }),
 
-        comp.getSizes({ source: "    ", minified: true, gzip: true }).then(sizes => {
+        comp.getSizes({ source: "    ", minified: true, gzip: true }).then((sizes) => {
           expect(sizes).to.eql(Object.assign({}, EMPTY_SIZES_GZ, {
             full: 4
           }));
@@ -56,7 +56,7 @@ describe("lib/utils/compressor", () => {
       return Promise.all([
         comp.getSizes({
           source: "const foo = () => 'foo';"
-        }).then(sizes => {
+        }).then((sizes) => {
           expect(sizes).to.eql(Object.assign({}, EMPTY_SIZES, {
             full: 24
           }));
@@ -65,7 +65,7 @@ describe("lib/utils/compressor", () => {
         comp.getSizes({
           source: "const foo = () => 'foo';",
           minified: true, gzip: true
-        }).then(sizes => {
+        }).then((sizes) => {
           expect(sizes).to.eql({
             full: 24,
             min: 20,
@@ -79,9 +79,9 @@ describe("lib/utils/compressor", () => {
       return create().getSizes({
         source: "**SYNTAX_ERROR**",
         minified: true, gzip: true
-      }).then(sizes => {
+      }).then((sizes) => {
         throw new Error(`Expected failure. Instead got: ${JSON.stringify(sizes)}`);
-      }).catch(err => {
+      }).catch((err) => {
         expect(err).to.have.property("message", "Unexpected token: operator (**)");
       });
     });
@@ -102,7 +102,7 @@ var UPDATE_LOCATION = "@angular-redux/router::UPDATE_LOCATION";
 /***/ })
 `,
         minified: true, gzip: true
-      }).then(sizes => {
+      }).then((sizes) => {
         expect(sizes).to.eql({
           full: 310,
           min: 111,

--- a/test/smoke.spec.js
+++ b/test/smoke.spec.js
@@ -199,9 +199,7 @@ describe("Smoke tests", () => {
 
     it("runs actions faster in the daemon with a cache", () => {
       const daemon = InspectpackDaemon.create({
-        cache: Cache.create({
-          filename: path.join(testOutputDir, ".inspectpack-test-cache.db")
-        })
+        cacheFilename: path.join(testOutputDir, ".inspectpack-test-cache.db")
       });
 
       const cache = daemon._cache;

--- a/test/smoke.spec.js
+++ b/test/smoke.spec.js
@@ -190,14 +190,13 @@ describe("Smoke tests", () => {
   );
 
   describe("daemon", () => {
-    beforeEach(function () {
-      this.timeout(20000); // Extended timeout.
-      return mkdirp(testOutputDir);
-    });
+    beforeEach(() => mkdirp(testOutputDir));
 
     afterEach((done) => rimraf(testOutputDir, done));
 
-    it("runs actions faster in the daemon with a cache", () => {
+    it("runs actions faster in the daemon with a cache", function () {
+      this.timeout(20000); // Extended timeout.
+
       const daemon = InspectpackDaemon.create({
         cacheFilename: path.join(testOutputDir, ".inspectpack-test-cache.db")
       });
@@ -264,7 +263,9 @@ describe("Smoke tests", () => {
         });
     });
 
-    it("runs actions correctly in the daemon without a cache", () => {
+    it("runs actions correctly in the daemon without a cache", function () {
+      this.timeout(20000); // Extended timeout.
+
       const daemon = InspectpackDaemon.create({
         cache: NoopCache.create()
       });

--- a/test/smoke.spec.js
+++ b/test/smoke.spec.js
@@ -272,6 +272,7 @@ describe("Smoke tests", () => {
       });
       const cache = daemon._cache;
       sandbox.spy(cache, "get");
+      sandbox.spy(cache, "wrapAction");
 
       // Verify empty cache.
       expect(cache).to.be.an.instanceOf(NoopCache);
@@ -283,9 +284,10 @@ describe("Smoke tests", () => {
         gzip: false
       })
         .then(() => {
-          // Cache miss.
-          expect(cache.get).to.have.callCount(1);
-          expect(cache.get.returnValues[0]).to.equal(null);
+          // Cache get is not even called using `NoopCache.wrapAction`.
+          expect(cache.get).to.have.callCount(0);
+          expect(cache.wrapAction).to.have.callCount(1);
+          expect(cache.wrapAction.returnValues[0]).to.be.an.instanceOf(Function);
 
           return daemon.sizes({
             code: fixtures.badBundle,
@@ -295,9 +297,9 @@ describe("Smoke tests", () => {
           });
         })
         .then(() => {
-          // Cache miss.
-          expect(cache.get).to.have.callCount(2);
-          expect(cache.get.returnValues[1]).to.equal(null);
+          expect(cache.get).to.have.callCount(0);
+          expect(cache.wrapAction).to.have.callCount(2);
+          expect(cache.wrapAction.returnValues[1]).to.be.an.instanceOf(Function);
         });
     });
   });

--- a/test/smoke.spec.js
+++ b/test/smoke.spec.js
@@ -213,7 +213,6 @@ describe("Smoke tests", () => {
       const coldStart = process.hrtime();
       let coldTime;
       let hotStart;
-      let hotTime;
 
       return daemon.sizes({
         code: fixtures.badBundle,
@@ -239,7 +238,8 @@ describe("Smoke tests", () => {
         })
         .then(() => {
           const time = process.hrtime(hotStart);
-          hotTime = time[0] * NS_PER_SEC + time[1];
+          const hotTime = time[0] * NS_PER_SEC + time[1];
+
           // Fail if the hot run isn't way faster than the cold run.
           // This indicates that the cache is failing.
           //

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,6 +684,10 @@ diff@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
+diff@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
+
 diffie-hellman@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.2.tgz#b5835739270cfe26acf632099fded2a07f209e5e"
@@ -1111,6 +1115,12 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formatio@1.2.0, formatio@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
+  dependencies:
+    samsam "1.x"
 
 formidable-playbook@^0.1.2:
   version "0.1.2"
@@ -1556,6 +1566,10 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -1627,6 +1641,10 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+just-extend@^1.1.22:
+  version "1.1.22"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.22.tgz#3330af756cab6a542700c64b2e4e4aa062d52fff"
 
 kind-of@^3.0.2:
   version "3.2.2"
@@ -1783,6 +1801,14 @@ lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, l
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
+
+lolex@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.1.2.tgz#2694b953c9ea4d013e5b8bfba891c991025b2629"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -1907,9 +1933,23 @@ nan@^2.3.0, nan@^2.4.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
 
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+nise@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.1.0.tgz#37e41b9bf0041ccb83d1bf03e79440bbc0db10ad"
+  dependencies:
+    formatio "^1.2.0"
+    just-extend "^1.1.22"
+    lolex "^1.6.0"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 node-libs-browser@^2.0.0:
   version "2.0.0"
@@ -2128,6 +2168,12 @@ path-is-inside@^1.0.1:
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -2454,6 +2500,10 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, 
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
+
 "semver@2 || 3 || 4 || 5", semver@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
@@ -2487,6 +2537,25 @@ shelljs@^0.7.5:
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon-chai@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-2.13.0.tgz#b9a42e801c20234bfc2f43b29e6f4f61b60990c4"
+
+sinon@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.0.0.tgz#a54a5f0237aa1dd2215e5e81c89b42b50c4fdb6b"
+  dependencies:
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lodash.get "^4.4.2"
+    lolex "^2.1.2"
+    native-promise-only "^0.8.1"
+    nise "^1.1.0"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -2688,6 +2757,10 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+text-encoding@0.6.4, text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -2751,6 +2824,10 @@ type-detect@0.1.1:
 type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
+
+type-detect@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
* Make `better-sqlite3` and `optionalDependency`. Switch to noop cache if not present. Fixes #49
* Add `Cache.wrapAction` helper for common use case of "try cache get, do action, set cache".
* Change cross-process communication to just serialize/deserialize the applicable cache instance.
* Various refactoring and cleanup.
* Re-enabled eslint rules for better hamonized style.
* Add `cache` option for `InspectpackDaemon.create`.
* Add error logging for worker errors.

/cc @tptee @gartz