### PR TITLE
Handle weird, quasi-buffer objects.

### DIFF
--- a/lib/models/bundle.js
+++ b/lib/models/bundle.js
@@ -282,20 +282,36 @@ const createBundle = (opts, callback) => {
  * @returns {void}
  */
 Bundle.create = function (opts, callback) {
+  // Mutate code into proper usable format.
+  let code = opts.code;
+  if (typeof code !== "string") {
+    if (Buffer.isBuffer(code)) {
+      code = code.toString();
+
+    // Check and convert code type if weird `{ type: "Buffer", data: [INTEGERS] }`
+    // https://github.com/FormidableLabs/webpack-dashboard/issues/193
+    } else if (code && code.type === "Buffer" && Array.isArray(code.data)) {
+      //console.log("MY BUFFER YO", Buffer.from(code.data).toString());
+
+    } else {
+      throw new Error(`Unknown type: ${typeof code} for code: ${code}`);
+    }
+  }
+
   // Validate. (Would be programming error).
-  if (!opts.bundle && !opts.code) {
+  if (!opts.bundle && !code) {
     throw new Error("Bundle or code option required");
   }
 
-  if (opts.bundle && opts.code) {
+  if (opts.bundle && code) {
     throw new Error("Bundle and code options are mutually exclusive");
   }
 
-  if (opts.code) {
+  if (code) {
     // Prevent Zalgo by executing on the next tick.
     return setImmediate(() => {
       createBundle({
-        code: opts.code,
+        code,
         allowEmpty: opts.allowEmpty
       }, callback);
     });

--- a/lib/models/bundle.js
+++ b/lib/models/bundle.js
@@ -284,17 +284,17 @@ const createBundle = (opts, callback) => {
 Bundle.create = function (opts, callback) {
   // Mutate code into proper usable format.
   let code = opts.code;
-  if (typeof code !== "string") {
+  if (code && typeof code !== "string") {
     if (Buffer.isBuffer(code)) {
       code = code.toString();
 
     // Check and convert code type if weird `{ type: "Buffer", data: [INTEGERS] }`
     // https://github.com/FormidableLabs/webpack-dashboard/issues/193
-    } else if (code && code.type === "Buffer" && Array.isArray(code.data)) {
-      //console.log("MY BUFFER YO", Buffer.from(code.data).toString());
+    } else if (code.type === "Buffer" && Array.isArray(code.data)) {
+      code = Buffer.from(code.data).toString();
 
     } else {
-      throw new Error(`Unknown type: ${typeof code} for code: ${code}`);
+      throw new Error(`Unknown code type: ${typeof code}, source: ${code}`);
     }
   }
 

--- a/test/playbook.spec.js
+++ b/test/playbook.spec.js
@@ -146,6 +146,54 @@ describe("Playbook", () => {
     });
   });
 
+  describe("bundle variable types", () => {
+    it("handles string bundle", () =>
+      sizes({
+        code: fixtures.scopeHoisting["app3.nohoist"],
+        format: "object",
+        minified: false,
+        gzip: false
+      })
+        .then((results) => {
+          expect(results).to.have.property("sizes").that.has.lengthOf(4);
+        })
+    );
+
+    it("handles buffer bundles", () =>
+      sizes({
+        code: new Buffer(fixtures.scopeHoisting["app3.nohoist"]),
+        format: "object",
+        minified: false,
+        gzip: false
+      })
+        .then((results) => {
+          expect(results).to.have.property("sizes").that.has.lengthOf(4);
+        })
+    );
+
+    // Regression Test: https://github.com/FormidableLabs/webpack-dashboard/issues/193
+    //
+    // Can get a plain JS object like: `{ type: "Buffer", data: [INTEGERS] }`
+    // where the data is really an array buffer of integers for a real `Buffer`.
+    it("handles the weird {type,data} serialized buffer-like-thing", () => {
+      const raw = new Buffer(fixtures.scopeHoisting["app3.nohoist"]);
+      const weirdObj = {
+        type: "Buffer",
+        data: Array.from(raw)
+      };
+
+      return sizes({
+        code: weirdObj,
+        format: "object",
+        minified: false,
+        gzip: false
+      })
+        .then((results) => {
+          expect(results).to.have.property("sizes").that.has.lengthOf(4);
+        });
+    });
+  });
+
   describe("scope hoisting", () => {
     it("parses all bundle parts", () =>
       Promise.all([

--- a/test/playbook.spec.js
+++ b/test/playbook.spec.js
@@ -192,6 +192,21 @@ describe("Playbook", () => {
           expect(results).to.have.property("sizes").that.has.lengthOf(4);
         });
     });
+
+    it("errors on unknown type", () =>
+      sizes({
+        code: { type: "weird" },
+        format: "object",
+        minified: false,
+        gzip: false
+      })
+        .then(() => {
+          throw new Error("Expected error for unkown type");
+        })
+        .catch((err) => {
+          expect(err).to.have.property("message").that.contains("Unknown code type");
+        })
+    );
   });
 
   describe("scope hoisting", () => {


### PR DESCRIPTION
* Handle weird `{ type: "Buffer", data: [INTEGERS] }` plain JavaScript object by detecting and converting it manually to a real `Buffer` object, then string. Fixes https://github.com/FormidableLabs/webpack-dashboard/issues/193

@jpduckwo @servicelevel -- Can you try out this version of inspectpack to see if this solves your issues with `TypeError: this.input.charCodeAt is not a function` in `webpack-dashboard`?

/cc @tptee 