### PR TITLE
Bug: fix path to package inference

### DIFF
--- a/src/lib/actions/base.ts
+++ b/src/lib/actions/base.ts
@@ -62,8 +62,25 @@ export const _getBaseName = (name: string): string | null => {
   const lastName = parts[parts.length - 1];
 
   // Normalize out the rest of the string.
-  const candidate = normalize(relative(".", lastName));
-  return candidate === "." ? "" : toPosixPath(candidate);
+  let candidate = normalize(relative(".", lastName));
+
+  // Short-circuit on empty string / current path.
+  if (candidate === ".") {
+    return "";
+  }
+
+  // Special case -- synthetic modules can end up with trailing `/` because
+  // of a regular expression. Preserve this.
+  //
+  // E.g., `/PATH/TO/node_modules/moment/locale sync /es/`
+  //
+  // **Note**: The rest of this tranform _should_ be safe for synthetic regexps,
+  // but we can always revisit.
+  if (name[name.length - 1] === "/") {
+    candidate += "/";
+  }
+
+  return toPosixPath(candidate);
 };
 
 export abstract class Action {

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -93,6 +93,10 @@ const allPackages = (mods: IModule[]): string[] => {
       const lastIdx = parts.length - 1;
       parts[lastIdx] = _packageName(parts[lastIdx]);
 
+      // console.log("TODO HERE ALL PKGS", JSON.stringify({
+      //   parts
+      // }, null, 2))
+
       parts.forEach((pkgName) => {
         pkgs[pkgName] = true;
       });
@@ -136,11 +140,27 @@ const modulesByPackageNameByPackagePath = (
     const pkgMap = modsMap[pkgName];
     const pkgPath = mod.identifier.substr(0, mod.identifier.length - mod.baseName.length)
       + normalize(pkgName);
+
+    // TODO: BUG -- identifier ends with `/`.
+
+    console.log("TODO HERE PKG PATH", JSON.stringify({
+      pkgName,
+      pkgPath,
+      id: mod.identifier,
+      idLen: mod.identifier.length,
+      base: mod.baseName,
+      baseLen: mod.baseName.length,
+    }, null, 2));
     pkgMap[pkgPath] = (pkgMap[pkgPath] || []).concat(mod);
   });
 
   // Now, remove any single item keys (no duplicates).
   Object.keys(modsMap).forEach((pkgName) => {
+    console.log("TODO HERE DELETE", JSON.stringify({
+      pkgName,
+      keys: Object.keys(modsMap[pkgName]),
+      //entry: modsMap[pkgName]
+    }, null, 2));
     if (Object.keys(modsMap[pkgName]).length === 1) {
       delete modsMap[pkgName];
     }

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { join, normalize, relative, sep } from "path";
+import { join, relative, sep } from "path";
 
 import { IActionModule, IModule } from "../interfaces/modules";
 import {
@@ -93,10 +93,6 @@ const allPackages = (mods: IModule[]): string[] => {
       const lastIdx = parts.length - 1;
       parts[lastIdx] = _packageName(parts[lastIdx]);
 
-      // console.log("TODO HERE ALL PKGS", JSON.stringify({
-      //   parts
-      // }, null, 2))
-
       parts.forEach((pkgName) => {
         pkgs[pkgName] = true;
       });
@@ -136,31 +132,22 @@ const modulesByPackageNameByPackagePath = (
     modsMap[pkgName] = modsMap[pkgName] || {};
 
     // Insert package path. (All the different installs of package).
-    // **Note**: use `normalize` to convert package name _back_ to windows if applicable.
     const pkgMap = modsMap[pkgName];
-    const pkgPath = mod.identifier.substr(0, mod.identifier.length - mod.baseName.length)
-      + normalize(pkgName);
+    const modParts = mod.identifier.split(sep);
+    const nmIndex = modParts.lastIndexOf("node_modules");
+    const pkgPath = modParts
+      // Remove base name path suffix.
+      .slice(0, nmIndex + 1)
+      // Add in parts of the package name (split with "/" because posixified).
+      .concat(pkgName.split("/"))
+      // Back to string.
+      .join(sep);
 
-    // TODO: BUG -- identifier ends with `/`.
-
-    console.log("TODO HERE PKG PATH", JSON.stringify({
-      pkgName,
-      pkgPath,
-      id: mod.identifier,
-      idLen: mod.identifier.length,
-      base: mod.baseName,
-      baseLen: mod.baseName.length,
-    }, null, 2));
     pkgMap[pkgPath] = (pkgMap[pkgPath] || []).concat(mod);
   });
 
   // Now, remove any single item keys (no duplicates).
   Object.keys(modsMap).forEach((pkgName) => {
-    console.log("TODO HERE DELETE", JSON.stringify({
-      pkgName,
-      keys: Object.keys(modsMap[pkgName]),
-      //entry: modsMap[pkgName]
-    }, null, 2));
     if (Object.keys(modsMap[pkgName]).length === 1) {
       delete modsMap[pkgName];
     }

--- a/test/fixtures/scoped/node_modules/bar/index.js
+++ b/test/fixtures/scoped/node_modules/bar/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  bar() {
+    return "bar";
+  }
+};

--- a/test/fixtures/scoped/node_modules/bar/package.json
+++ b/test/fixtures/scoped/node_modules/bar/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "bar",
+  "version": "1.1.1",
+  "description": "bar",
+  "main": "index.js"
+}

--- a/test/fixtures/scoped/node_modules/bar/tender.js
+++ b/test/fixtures/scoped/node_modules/bar/tender.js
@@ -1,0 +1,5 @@
+module.exports = {
+  cocktail() {
+    return "old fashioned";
+  }
+};

--- a/test/fixtures/scoped/package.json
+++ b/test/fixtures/scoped/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@scope/foo": "^1.0.0",
+    "bar": "^1.0.0",
     "different-foo": "^1.0.1",
     "flattened-foo": "^1.1.0",
     "unscoped-foo": "^1.0.9",

--- a/test/fixtures/scoped/src/index.js
+++ b/test/fixtures/scoped/src/index.js
@@ -5,6 +5,8 @@ const { bike } = require("@scope/foo/bike");
 const { usesFoo } = require("uses-foo");
 const { unscopedFoo, deeperUnscopedFoo } = require("unscoped-foo");
 const { flattenedFoo } = require("flattened-foo");
+const { bar } = require("bar");
+const { cocktail } = require("bar/tender");
 
 console.log("foo", foo());
 console.log("foo/bike", bike());
@@ -12,3 +14,5 @@ console.log("usesFoo", usesFoo());
 console.log("flattenedFoo", flattenedFoo());
 console.log("unscopedFoo", unscopedFoo());
 console.log("deeperUnscopedFoo", deeperUnscopedFoo());
+console.log("bar", bar());
+console.log("cocktail", cocktail());

--- a/test/lib/actions/base.spec.ts
+++ b/test/lib/actions/base.spec.ts
@@ -27,6 +27,13 @@ describe("lib/actions/base", () => {
       expect(_getBaseName("bruh\\node_modules\\bar\\foo.js")).to.equal("bar/foo.js");
     });
 
+    it("handles synthetic modules", () => {
+      expect(_getBaseName("node_modules/moment/locale sync /es/"))
+        .to.equal("moment/locale sync /es/");
+      expect(_getBaseName("node_modules\\moment/locale sync /es/"))
+        .to.equal("moment/locale sync /es/");
+    });
+
     // All of this behavior is negotiable.
     it("handles weird cases that should never come up", () => {
       expect(_getBaseName("node_modules")).to.equal("");

--- a/test/lib/actions/sizes.spec.ts
+++ b/test/lib/actions/sizes.spec.ts
@@ -14,7 +14,7 @@ import {
 } from "../../utils";
 
 const PATCHED_MOMENT_LOCALE_ES = {
-  baseName: "moment/locale sync /es",
+  baseName: "moment/locale sync /es/",
   identifier: resolve(__dirname, "../../../node_modules/moment/locale sync /es/"),
   size: 100,
   source: "REMOVED",
@@ -22,10 +22,10 @@ const PATCHED_MOMENT_LOCALE_ES = {
 
 // Keyed off `baseName`.
 const PATCHED_MODS = {
-  "moment/locale /es": PATCHED_MOMENT_LOCALE_ES,
-  "moment/locale sync /es": PATCHED_MOMENT_LOCALE_ES,
+  "moment/locale /es/": PATCHED_MOMENT_LOCALE_ES,
+  "moment/locale sync /es/": PATCHED_MOMENT_LOCALE_ES,
   "webpack/buildin/module.js": {
-    baseName: "moment/locale sync /es",
+    baseName: "webpack/buildin/module.js",
     identifier: resolve(__dirname, "../../../node_modules/webpack/buildin/module.js"),
     size: 200,
     source: "REMOVED",
@@ -291,6 +291,20 @@ describe("lib/actions/sizes", () => {
                     },
                   },
                   {
+                    baseName: "bar/index.js",
+                    fileName: "scoped/node_modules/bar/index.js",
+                    size: {
+                      full: "NUM",
+                    },
+                  },
+                  {
+                    baseName: "bar/tender.js",
+                    fileName: "scoped/node_modules/bar/tender.js",
+                    size: {
+                      full: "NUM",
+                    },
+                  },
+                  {
                     baseName: "flattened-foo/index.js",
                     fileName: "scoped/node_modules/flattened-foo/index.js",
                     size: {
@@ -405,6 +419,10 @@ inspectpack --action=sizes
   * Size: NUM
 * scoped/node_modules/@scope/foo/index.js
   * Size: NUM
+* scoped/node_modules/bar/index.js
+  * Size: NUM
+* scoped/node_modules/bar/tender.js
+  * Size: NUM
 * scoped/node_modules/flattened-foo/index.js
   * Size: NUM
 * scoped/node_modules/unscoped-foo/index.js
@@ -441,6 +459,8 @@ inspectpack --action=sizes
 Asset	Full Name	Short Name	Size
 bundle.js	scoped/node_modules/@scope/foo/bike.js	@scope/foo/bike.js	NUM
 bundle.js	scoped/node_modules/@scope/foo/index.js	@scope/foo/index.js	NUM
+bundle.js	scoped/node_modules/bar/index.js	bar/index.js	NUM
+bundle.js	scoped/node_modules/bar/tender.js	bar/tender.js	NUM
 bundle.js	scoped/node_modules/flattened-foo/index.js	flattened-foo/index.js	NUM
 bundle.js	scoped/node_modules/unscoped-foo/index.js	unscoped-foo/index.js	NUM
 bundle.js	scoped/node_modules/unscoped-foo/node_modules/deeper-unscoped/index.js	deeper-unscoped/index.js	NUM

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -766,5 +766,9 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	duplicates-cjs@1.2.3 
       expect(_packageName("  @scope/foo/index.js")).to.equal("@scope/foo");
       expect(_packageName("@scope/foo/bar/car.js")).to.equal("@scope/foo");
     });
+
+    it("handles synthetic packages", () => {
+      expect(_packageName("moment/locale sync /es/")).to.equal("moment");
+    });
   });
 });


### PR DESCRIPTION
Originally, a simple `substr` of the `identifier` (unprocessed) from the (processed) `baseName` was used to slice off the part of a full path to a node_modules file. This ended up with incorrect paths to modules.

Now, we actually split then rejoin the path more reliably.

Also adds some test fixtures and does some futzing to baseName for synthetic modules.