### PR TITLE
BUG: package.json:bin is missing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: node_js
 node_js:
   - "6"
   - "8"
-  - "10"
+  # `mock-fs` doesn't support `node@10.5+`
+  # https://github.com/FormidableLabs/inspectpack/issues/83
+  - "10.4"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,9 @@ environment:
   matrix:
     - nodejs_version: "6"
     - nodejs_version: "8"
-    - nodejs_version: "10"
+    # `mock-fs` doesn't support `node@10.5+`
+    # https://github.com/FormidableLabs/inspectpack/issues/83
+    - nodejs_version: "10.4"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "expose-loader": "^0.7.5",
     "inspectpack-test-fixtures": "file:test/fixtures",
     "mocha": "^5.1.0",
-    "mock-fs": "^4.4.2",
+    "mock-fs": "^4.6.0",
     "nyc": "^11.6.0",
     "raw-loader": "^0.5.1",
     "rimraf": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "3.0.1",
   "description": "An inspection tool for Webpack frontend JavaScript bundles.",
   "main": "lib/index.js",
+  "bin": {
+    "inspectpack": "bin/inspectpack.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/FormidableLabs/inspectpack.git"

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -179,8 +179,7 @@ describe("lib/actions/versions", () => {
     });
 
     describe("node_modules scenarios", () => {
-      // TODO: REENABLE - EXPERIMENT
-      it.skip("errors on malformed root package.json", () => {
+      it("errors on malformed root package.json", () => {
         mock({
           "test/fixtures/duplicates-cjs": {
             "package.json": "BAD_NOT_JSON",

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -179,7 +179,8 @@ describe("lib/actions/versions", () => {
     });
 
     describe("node_modules scenarios", () => {
-      it("errors on malformed root package.json", () => {
+      // TODO: REENABLE - EXPERIMENT
+      it.skip("errors on malformed root package.json", () => {
         mock({
           "test/fixtures/duplicates-cjs": {
             "package.json": "BAD_NOT_JSON",

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -113,6 +113,11 @@ describe("lib/actions/versions", () => {
         scopedInstance,
         multipleRootsInstance,
       ] = instances;
+
+      expect(simpleInstance).to.not.be.an("undefined");
+      expect(dupsCjsInstance).to.not.be.an("undefined");
+      expect(scopedInstance).to.not.be.an("undefined");
+      expect(multipleRootsInstance).to.not.be.an("undefined");
     }),
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4145,9 +4145,9 @@ mocha@^5.1.0:
     mkdirp "0.5.1"
     supports-color "4.4.0"
 
-mock-fs@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.4.2.tgz#09dec5313f97095a450be6aa2ad8ab6738d63d6b"
+mock-fs@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.6.0.tgz#d944ef4c3e03ceb4e8332b4b31b8ac254051c8ae"
 
 moment@2.22.1:
   version "2.22.1"


### PR DESCRIPTION
- Add missing `package.json:bin` entry. Fixes #81 
- Update travis config to not do `node@10.5+`. See #83 