### PR TITLE
Add `emitHandler` option to `DuplicatesPlugin` to allow customized output

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
 History
 =======
 
+## Unreleased
+
+- Add `emitHandler` option to `DuplicatesPlugin` to allow customized output.
+
 ## 4.0.1
 
 * BUG: CLI execution fails from command line. (Missing shebang.)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ module.exports = {
     new DuplicatesPlugin({
       // Emit compilation warning or error? (Default: `false`)
       emitErrors: false,
-      // Handle all messages with handler function (`(messages[], compilation)`)
+      // Handle all messages with handler function (`(report: string)`)
       // Overrides `emitErrors` output.
       emitHandler: undefined,
       // Display full duplicates information? (Default: `false`)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ module.exports = {
     new DuplicatesPlugin({
       // Emit compilation warning or error? (Default: `false`)
       emitErrors: false,
+      // Handle all messages with handler function (`(messages[], compilation)`)
+      // Overrides `emitErrors` output.
+      emitHandler: undefined,
       // Display full duplicates information? (Default: `false`)
       verbose: false
     })

--- a/src/plugin/duplicates.ts
+++ b/src/plugin/duplicates.ts
@@ -39,7 +39,7 @@ interface IDuplicatesByFile {
 interface IDuplicatesPluginConstructor {
   verbose?: boolean;
   emitErrors?: boolean;
-  emitHandler?: (msgs: string[], compilation?: ICompilation) => {};
+  emitHandler?: (report: string) => {};
 }
 
 interface IPackageNames {
@@ -317,11 +317,12 @@ export class DuplicatesPlugin {
         // tslint:enable max-line-length
 
         // Drain messages into custom handler or warnings/errors.
+        const report = msgs.join("\n");
         if (emitHandler) {
-          emitHandler(msgs, compilation);
+          emitHandler(report);
         } else {
           const output = emitErrors ? errors : warnings;
-          output.push(new Error(msgs.join("\n")));
+          output.push(new Error(report));
         }
       })
       // Handle old plugin API callback.

--- a/src/plugin/duplicates.ts
+++ b/src/plugin/duplicates.ts
@@ -39,6 +39,7 @@ interface IDuplicatesByFile {
 interface IDuplicatesPluginConstructor {
   verbose?: boolean;
   emitErrors?: boolean;
+  emitHandler?: (msgs: string[], compilation?: ICompilation) => {};
 }
 
 interface IPackageNames {
@@ -172,6 +173,7 @@ export class DuplicatesPlugin {
     this.opts = {};
     this.opts.verbose = opts.verbose === true; // default `false`
     this.opts.emitErrors = opts.emitErrors === true; // default `false`
+    this.opts.emitHandler = typeof opts.emitHandler === "function" ? opts.emitHandler : undefined;
   }
 
   public apply(compiler: ICompiler) {
@@ -188,7 +190,7 @@ export class DuplicatesPlugin {
     const { errors, warnings } = compilation;
     const stats = compilation.getStats().toJson();
 
-    const { emitErrors, verbose } = this.opts;
+    const { emitErrors, emitHandler, verbose } = this.opts;
 
     // Stash messages for output to console (success) or compilation warnings
     // or errors arrays on duplicates found.
@@ -314,9 +316,13 @@ export class DuplicatesPlugin {
 `.trimLeft());
         // tslint:enable max-line-length
 
-        // Drain messages into warnings or Errors.
-        const output = emitErrors ? errors : warnings;
-        output.push(new Error(msgs.join("\n")));
+        // Drain messages into custom handler or warnings/errors.
+        if (emitHandler) {
+          emitHandler(msgs, compilation);
+        } else {
+          const output = emitErrors ? errors : warnings;
+          output.push(new Error(msgs.join("\n")));
+        }
       })
       // Handle old plugin API callback.
       .then(() => {

--- a/test/lib/plugin/duplicates.spec.ts
+++ b/test/lib/plugin/duplicates.spec.ts
@@ -255,6 +255,41 @@ foo (Found 1 resolved, 2 installed, 2 depended. Latest 1.1.1.)
                   .has.property("message", verboseReport);
             });
           });
+
+          it(`emits to handler to default report`, () => {
+            const emitHandler = sandbox.spy();
+            const plugin = new DuplicatesPlugin({
+              emitHandler,
+            });
+
+            return plugin.analyze(compilation).then(() => {
+              expect(compilation.warnings).to.eql([]);
+              expect(compilation.errors).to.eql([]);
+              expect(emitHandler).to.have.callCount(1);
+
+              // First call, first argument is the report
+              const actualReport = emitHandler.args[0][0];
+              expect(actualReport).to.eql(defaultReport);
+            });
+          });
+
+          it(`emits to handler to verbose report`, () => {
+            const emitHandler = sandbox.spy();
+            const plugin = new DuplicatesPlugin({
+              emitHandler,
+              verbose: true,
+            });
+
+            return plugin.analyze(compilation).then(() => {
+              expect(compilation.warnings).to.eql([]);
+              expect(compilation.errors).to.eql([]);
+              expect(emitHandler).to.have.callCount(1);
+
+              // First call, first argument is the report
+              const actualReport = emitHandler.args[0][0];
+              expect(actualReport).to.eql(verboseReport);
+            });
+          });
         });
 
       });


### PR DESCRIPTION
Allows us to actually get output on next / builds that totally wrap webpack:

```js
      new DuplicatesPlugin({
        verbose: true,
        emitHandler: (report) => {
          console.log(report);
        }
      })
```

/cc @tptee 