### PR TITLE
BUG: more identifier normalization

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,13 @@
 History
 =======
 
+## UNRELEASED
+
+- BUG: Use `name` field to better process `identifier` to remove things like
+  `/PATH/TO/node_modules/font-awesome/font-awesome.css 0"`. May result in some
+  `baseName`s being identical despite different `identifier`s because of
+  loaders and generated code.
+
 ## 4.1.1
 
 - BUG: A loader in the `identifier` field would incorrectly have all modules inferred "as a `node_modules` file", even if not. Implements a naive loader stripping heuristic to correctly assess if `node_modules` or real application source.

--- a/src/lib/actions/base.ts
+++ b/src/lib/actions/base.ts
@@ -51,17 +51,48 @@ export const _isNodeModules = (name: string): boolean => nodeModulesParts(name).
 // First, strip off anything before a `?` and `!`:
 // - `REMOVE?KEEP`
 // - `REMOVE!KEEP`
-export const _normalizeWebpackPath = (name: string): string => {
-  const lastBang = name.lastIndexOf("!");
-  const lastQuestion = name.lastIndexOf("?");
-  const prefixEnd = Math.max(lastBang, lastQuestion);
+export const _normalizeWebpackPath = (identifier: string, name?: string): string => {
+  const bangLastIdx = identifier.lastIndexOf("!");
+  const questionLastIdx = identifier.lastIndexOf("?");
+  const prefixEnd = Math.max(bangLastIdx, questionLastIdx);
+
+  let candidate = identifier;
 
   // Remove prefix here.
   if (prefixEnd > -1) {
-    return name.substr(prefixEnd + 1);
+    candidate = candidate.substr(prefixEnd + 1);
   }
 
-  return name;
+  // Assume a normalized then truncate to name if applicable.
+  //
+  // E.g.,
+  // - `identifier`: "css /PATH/TO/node_modules/cache-loader/dist/cjs.js!STUFF
+  //   !/PATH/TO/node_modules/font-awesome/css/font-awesome.css 0"
+  // - `name`: "node_modules/font-awesome/css/font-awesome.css"
+  //
+  // Forms of name:
+  // - v1, v2: "/PATH/TO/ROOT/~/pkg/index.js"
+  // - v3: "/PATH/TO/ROOT/node_modules/pkg/index.js"
+  // - v4: "./node_modules/pkg/index.js"
+  if (name) {
+    name = name
+      .replace("/~/", "/node_modules/")
+      .replace("\\~\\", "\\node_modules\\");
+
+    if (name.startsWith("./") || name.startsWith(".\\")) {
+      // Remove dot-slash relative part.
+      name = name.slice(2);
+    }
+
+    // Now, truncate suffix of the candidate if name has less.
+    const nameLastIdx = candidate.lastIndexOf(name);
+    if (nameLastIdx > -1 && candidate.length !== nameLastIdx + name.length) {
+      const oldCandidate = candidate;
+      candidate = candidate.substr(0, nameLastIdx + name.length);
+    }
+  }
+
+  return candidate;
 };
 
 // Convert a `node_modules` name to a base name.
@@ -152,6 +183,7 @@ export abstract class Action {
           let isSynthetic = false;
           let source = null;
           let identifier;
+          let name;
           let size;
 
           if (RWebpackStatsModuleModules.decode(mod).isRight()) {
@@ -165,6 +197,7 @@ export abstract class Action {
             // Easy case -- a normal source code module.
             const srcMod = mod as IWebpackStatsModuleSource;
             identifier = srcMod.identifier;
+            name = srcMod.name;
             size = srcMod.size;
             source = srcMod.source;
 
@@ -172,6 +205,7 @@ export abstract class Action {
             // Catch-all case -- a module without modules or source.
             const syntheticMod = mod as IWebpackStatsModuleSynthetic;
             identifier = syntheticMod.identifier;
+            name = syntheticMod.name;
             size = syntheticMod.size;
             isSynthetic = true;
 
@@ -180,7 +214,8 @@ export abstract class Action {
           }
 
           // We've now got a single entry to prepare and add.
-          const normalizedId = _normalizeWebpackPath(identifier);
+          const normalizedName = _normalizeWebpackPath(name);
+          const normalizedId = _normalizeWebpackPath(identifier, normalizedName);
           const isNodeModules = _isNodeModules(normalizedId);
           const baseName = isNodeModules ? _getBaseName(normalizedId) : null;
 
@@ -190,6 +225,7 @@ export abstract class Action {
             identifier,
             isNodeModules,
             isSynthetic,
+            name: normalizedName,
             size,
             source,
           }]);

--- a/src/lib/actions/base.ts
+++ b/src/lib/actions/base.ts
@@ -87,7 +87,6 @@ export const _normalizeWebpackPath = (identifier: string, name?: string): string
     // Now, truncate suffix of the candidate if name has less.
     const nameLastIdx = candidate.lastIndexOf(name);
     if (nameLastIdx > -1 && candidate.length !== nameLastIdx + name.length) {
-      const oldCandidate = candidate;
       candidate = candidate.substr(0, nameLastIdx + name.length);
     }
   }

--- a/src/lib/actions/base.ts
+++ b/src/lib/actions/base.ts
@@ -180,7 +180,7 @@ export abstract class Action {
           }
 
           // We've now got a single entry to prepare and add.
-          const normalizedId = _normalizeWebpackPath(identifier as string);
+          const normalizedId = _normalizeWebpackPath(identifier);
           const isNodeModules = _isNodeModules(normalizedId);
           const baseName = isNodeModules ? _getBaseName(normalizedId) : null;
 

--- a/src/lib/actions/base.ts
+++ b/src/lib/actions/base.ts
@@ -45,10 +45,13 @@ export const nodeModulesParts = (name: string) => toPosixPath(name).split(NM_RE)
 // True if name is part of a `node_modules` path.
 export const _isNodeModules = (name: string): boolean => nodeModulesParts(name).length > 1;
 
-// Naively remove any prefix portion of an identifier, namely:
+// Attempt to "unwind" webpack paths in `identifier` and `name` to remove
+// prefixes and produce a normal, usable filepath.
+//
+// First, strip off anything before a `?` and `!`:
 // - `REMOVE?KEEP`
 // - `REMOVE!KEEP`
-export const _normalizeIdentifier = (name: string): string => {
+export const _normalizeWebpackPath = (name: string): string => {
   const lastBang = name.lastIndexOf("!");
   const lastQuestion = name.lastIndexOf("?");
   const prefixEnd = Math.max(lastBang, lastQuestion);
@@ -177,7 +180,7 @@ export abstract class Action {
           }
 
           // We've now got a single entry to prepare and add.
-          const normalizedId = _normalizeIdentifier(identifier as string);
+          const normalizedId = _normalizeWebpackPath(identifier as string);
           const isNodeModules = _isNodeModules(normalizedId);
           const baseName = isNodeModules ? _getBaseName(normalizedId) : null;
 

--- a/src/lib/actions/base.ts
+++ b/src/lib/actions/base.ts
@@ -224,7 +224,6 @@ export abstract class Action {
             identifier,
             isNodeModules,
             isSynthetic,
-            name: normalizedName,
             size,
             source,
           }]);

--- a/src/lib/interfaces/webpack-stats.ts
+++ b/src/lib/interfaces/webpack-stats.ts
@@ -49,8 +49,17 @@ const RWebpackStatsModuleBase = t.type({
   // Chunk identifiers.
   chunks: t.array(RWebpackStatsChunk),
   // Full path to file on disk (with extra hash stuff if `modules` module).
+   // Full path to file on disk (with extra hash stuff if `modules` module and
+  // loader prefixes, etc.).
   identifier: t.string,
-  // Estimated byte size of module.
+   // An absolute (webpack v1-3) or relative (webpack v4) name of the module.
+  //
+  // Forms:
+  // - v1, v2: "/PATH/TO/ROOT/~/pkg/index.js"
+  // - v3: "/PATH/TO/ROOT/node_modules/pkg/index.js"
+  // - v4: "./node_modules/pkg/index.js"
+  name: t.string,
+   // Estimated byte size of module.
   size: t.number,
 });
 

--- a/src/lib/interfaces/webpack-stats.ts
+++ b/src/lib/interfaces/webpack-stats.ts
@@ -43,7 +43,7 @@ const RWebpackStatsAssets = t.array(RWebpackStatsAsset);
 export type IWebpackStatsAssets = t.TypeOf<typeof RWebpackStatsAssets>;
 
 // ----------------------------------------------------------------------------
-// Module: Base type
+// Module: Base types
 // ----------------------------------------------------------------------------
 const RWebpackStatsModuleBase = t.type({
   // Chunk identifiers.
@@ -52,15 +52,19 @@ const RWebpackStatsModuleBase = t.type({
    // Full path to file on disk (with extra hash stuff if `modules` module and
   // loader prefixes, etc.).
   identifier: t.string,
-   // An absolute (webpack v1-3) or relative (webpack v4) name of the module.
+   // Estimated byte size of module.
+  size: t.number,
+});
+
+// Added fields for some modules that we _don't_ want in the base fields.
+const RWebpackStatsModuleWithName = t.type({
+  // An absolute (webpack v1-3) or relative (webpack v4) name of the module.
   //
   // Forms:
   // - v1, v2: "/PATH/TO/ROOT/~/pkg/index.js"
   // - v3: "/PATH/TO/ROOT/node_modules/pkg/index.js"
   // - v4: "./node_modules/pkg/index.js"
   name: t.string,
-   // Estimated byte size of module.
-  size: t.number,
 });
 
 export type IWebpackStatsModuleBase = t.TypeOf<typeof RWebpackStatsModuleBase>;
@@ -70,6 +74,7 @@ export type IWebpackStatsModuleBase = t.TypeOf<typeof RWebpackStatsModuleBase>;
 // ----------------------------------------------------------------------------
 export const RWebpackStatsModuleSource = t.intersection([
   RWebpackStatsModuleBase,
+  RWebpackStatsModuleWithName,
   t.type({
     // Raw source, stringified
     source: t.string,
@@ -108,8 +113,11 @@ export type IWebpackStatsModuleSource = t.TypeOf<typeof RWebpackStatsModuleSourc
 // ```
 // ----------------------------------------------------------------------------
 // Just alias base.
-export const RWebpackStatsModuleSynthetic = RWebpackStatsModuleBase;
-export type IWebpackStatsModuleSynthetic = IWebpackStatsModuleBase;
+export const RWebpackStatsModuleSynthetic = t.intersection([
+  RWebpackStatsModuleBase,
+  RWebpackStatsModuleWithName,
+]);
+export type IWebpackStatsModuleSynthetic = t.TypeOf<typeof RWebpackStatsModuleSynthetic>;
 
 // ----------------------------------------------------------------------------
 // Module: More **modules**

--- a/test/lib/actions/base.spec.ts
+++ b/test/lib/actions/base.spec.ts
@@ -56,11 +56,49 @@ describe("lib/actions/base", () => {
         .to.equal("/PATH/TO/node_modules/pkg/foo.js");
       expect(_normalizeWebpackPath("/PATH/TO/node_modules/css-loader/index.js??ref--7-1!/PATH/TO/node_modules/postcss-loader/lib/index.js??ref--7-2!/PATH/TO/node_modules/@scope/foo/package.css"))
         .to.equal("/PATH/TO/node_modules/@scope/foo/package.css");
+      expect(_normalizeWebpackPath("/PATH/TO/node_modules/css-loader/index.js??ref--7-1!/PATH/TO/node_modules/postcss-loader/lib/index.js??ref--7-2!/PATH/TO/node_modules/@scope/foo/package.css 0"))
+        .to.equal("/PATH/TO/node_modules/@scope/foo/package.css 0");
 
       expect(_normalizeWebpackPath("/PATH/TO/node_modules/next/dist/build/webpack/loaders/next-babel-loader.js??ref--4!/PATH/TO/src/modules/debug/foo.js"))
         .to.equal("/PATH/TO/src/modules/debug/foo.js");
       expect(_normalizeWebpackPath("/PATH/TO/node_modules/css-loader/index.js??ref--7-1!/PATH/TO/node_modules/postcss-loader/lib/index.js??ref--7-2!/PATH/TO/src/bar/my-style.css"))
         .to.equal("/PATH/TO/src/bar/my-style.css");
+    });
+
+    it("handles loaders with name param", () => {
+      expect(_normalizeWebpackPath("/PATH/TO/node_modules/css-loader/lib/css-base.js",
+        "/PATH/TO/~/css-loader/lib/css-base.js"))
+        .to.equal("/PATH/TO/node_modules/css-loader/lib/css-base.js");
+      expect(_normalizeWebpackPath("/PATH/TO/node_modules/css-loader/lib/css-base.js",
+        "/PATH/TO/~/css-loader/lib/css-base.js"))
+        .to.equal("/PATH/TO/node_modules/css-loader/lib/css-base.js");
+      expect(_normalizeWebpackPath("/PATH/TO/node_modules/css-loader/lib/css-base.js",
+        "./node_modules/css-loader/lib/css-base.js"))
+        .to.equal("/PATH/TO/node_modules/css-loader/lib/css-base.js");
+      expect(_normalizeWebpackPath("/PATH/TO/node_modules/css-loader/index.js??ref--7-1!/PATH/TO/node_modules/postcss-loader/lib/index.js??ref--7-2!/PATH/TO/node_modules/@scope/foo/package.css"))
+        .to.equal("/PATH/TO/node_modules/@scope/foo/package.css");
+
+      expect(_normalizeWebpackPath("/PATH/TO/node_modules/css-loader/index.js??ref--7-1!/PATH/TO/node_modules/postcss-loader/lib/index.js??ref--7-2!/PATH/TO/node_modules/@scope/foo/package.css 0",
+        "/PATH/TO/~/@scope/foo/package.css"))
+        .to.equal("/PATH/TO/node_modules/@scope/foo/package.css");
+      expect(_normalizeWebpackPath("x:\\PATH\\TO\\node_modules\\css-loader\\index.js??ref--7-1!x:\\PATH\\TO\\node_modules\\postcss-loader\\lib\\index.js??ref--7-2!x:\\PATH\\TO\\node_modules\\@scope\\foo\\package.css 0",
+        "x:\\PATH\\TO\\~\\@scope\\foo\\package.css"))
+        .to.equal("x:\\PATH\\TO\\node_modules\\@scope\\foo\\package.css");
+      expect(_normalizeWebpackPath("/PATH/TO/node_modules/css-loader/index.js??ref--7-1!/PATH/TO/node_modules/postcss-loader/lib/index.js??ref--7-2!/PATH/TO/node_modules/@scope/foo/package.css 0",
+        "/PATH/TO/node_modules/@scope/foo/package.css"))
+        .to.equal("/PATH/TO/node_modules/@scope/foo/package.css");
+      expect(_normalizeWebpackPath("x:\\PATH\\TO\\node_modules\\css-loader\\index.js??ref--7-1!x:\\PATH\\TO\\node_modules\\postcss-loader\\lib\\index.js??ref--7-2!x:\\PATH\\TO\\node_modules\\@scope\\foo\\package.css 0",
+        "x:\\PATH\\TO\\node_modules\\@scope\\foo\\package.css"))
+        .to.equal("x:\\PATH\\TO\\node_modules\\@scope\\foo\\package.css");
+      expect(_normalizeWebpackPath("/PATH/TO/node_modules/css-loader/index.js??ref--7-1!/PATH/TO/node_modules/postcss-loader/lib/index.js??ref--7-2!/PATH/TO/node_modules/@scope/foo/package.css 0",
+        "./node_modules/@scope/foo/package.css"))
+        .to.equal("/PATH/TO/node_modules/@scope/foo/package.css");
+      expect(_normalizeWebpackPath("x:\\PATH\\TO\\node_modules\\css-loader\\index.js??ref--7-1!x:\\PATH\\TO\\node_modules\\postcss-loader\\lib\\index.js??ref--7-2!x:\\PATH\\TO\\node_modules\\@scope\\foo\\package.css 0",
+        "node_modules\\@scope\\foo\\package.css"))
+        .to.equal("x:\\PATH\\TO\\node_modules\\@scope\\foo\\package.css");
+      expect(_normalizeWebpackPath("x:\\PATH\\TO\\node_modules\\css-loader\\index.js??ref--7-1!x:\\PATH\\TO\\node_modules\\postcss-loader\\lib\\index.js??ref--7-2!x:\\PATH\\TO\\node_modules\\@scope\\foo\\package.css 0",
+        ".\\node_modules\\@scope\\foo\\package.css"))
+        .to.equal("x:\\PATH\\TO\\node_modules\\@scope\\foo\\package.css");
     });
     // tslint:enable max-line-length
   });

--- a/test/lib/actions/base.spec.ts
+++ b/test/lib/actions/base.spec.ts
@@ -1,4 +1,4 @@
-import { _getBaseName, _isNodeModules, _normalizeIdentifier } from "../../../src/lib/actions/base";
+import { _getBaseName, _isNodeModules, _normalizeWebpackPath } from "../../../src/lib/actions/base";
 
 describe("lib/actions/base", () => {
   describe("_isNodeModules", () => {
@@ -36,30 +36,30 @@ describe("lib/actions/base", () => {
     });
   });
 
-  describe("_normalizeIdentifier", () => {
+  describe("_normalizeWebpackPath", () => {
     it("handles base cases", () => {
-      expect(_normalizeIdentifier("")).to.equal("");
-      expect(_normalizeIdentifier("foo.js")).to.equal("foo.js");
-      expect(_normalizeIdentifier("/foo.js")).to.equal("/foo.js");
-      expect(_normalizeIdentifier("\\foo.js")).to.equal("\\foo.js");
-      expect(_normalizeIdentifier("bar/foo.js")).to.equal("bar/foo.js");
-      expect(_normalizeIdentifier("bar\\foo.js")).to.equal("bar\\foo.js");
-      expect(_normalizeIdentifier("/bar/foo.js")).to.equal("/bar/foo.js");
-      expect(_normalizeIdentifier("x:\\bar\\foo.js")).to.equal("x:\\bar\\foo.js");
+      expect(_normalizeWebpackPath("")).to.equal("");
+      expect(_normalizeWebpackPath("foo.js")).to.equal("foo.js");
+      expect(_normalizeWebpackPath("/foo.js")).to.equal("/foo.js");
+      expect(_normalizeWebpackPath("\\foo.js")).to.equal("\\foo.js");
+      expect(_normalizeWebpackPath("bar/foo.js")).to.equal("bar/foo.js");
+      expect(_normalizeWebpackPath("bar\\foo.js")).to.equal("bar\\foo.js");
+      expect(_normalizeWebpackPath("/bar/foo.js")).to.equal("/bar/foo.js");
+      expect(_normalizeWebpackPath("x:\\bar\\foo.js")).to.equal("x:\\bar\\foo.js");
     });
 
     // tslint:disable max-line-length
     it("handles loaders", () => {
-      expect(_normalizeIdentifier("/PATH/TO/node_modules/css-loader/lib/css-base.js"))
+      expect(_normalizeWebpackPath("/PATH/TO/node_modules/css-loader/lib/css-base.js"))
         .to.equal("/PATH/TO/node_modules/css-loader/lib/css-base.js");
-      expect(_normalizeIdentifier("/PATH/TO/node_modules/next/dist/build/webpack/loaders/next-babel-loader.js??ref--4!/PATH/TO/node_modules/pkg/foo.js"))
+      expect(_normalizeWebpackPath("/PATH/TO/node_modules/next/dist/build/webpack/loaders/next-babel-loader.js??ref--4!/PATH/TO/node_modules/pkg/foo.js"))
         .to.equal("/PATH/TO/node_modules/pkg/foo.js");
-      expect(_normalizeIdentifier("/PATH/TO/node_modules/css-loader/index.js??ref--7-1!/PATH/TO/node_modules/postcss-loader/lib/index.js??ref--7-2!/PATH/TO/node_modules/@scope/foo/package.css"))
+      expect(_normalizeWebpackPath("/PATH/TO/node_modules/css-loader/index.js??ref--7-1!/PATH/TO/node_modules/postcss-loader/lib/index.js??ref--7-2!/PATH/TO/node_modules/@scope/foo/package.css"))
         .to.equal("/PATH/TO/node_modules/@scope/foo/package.css");
 
-      expect(_normalizeIdentifier("/PATH/TO/node_modules/next/dist/build/webpack/loaders/next-babel-loader.js??ref--4!/PATH/TO/src/modules/debug/foo.js"))
+      expect(_normalizeWebpackPath("/PATH/TO/node_modules/next/dist/build/webpack/loaders/next-babel-loader.js??ref--4!/PATH/TO/src/modules/debug/foo.js"))
         .to.equal("/PATH/TO/src/modules/debug/foo.js");
-      expect(_normalizeIdentifier("/PATH/TO/node_modules/css-loader/index.js??ref--7-1!/PATH/TO/node_modules/postcss-loader/lib/index.js??ref--7-2!/PATH/TO/src/bar/my-style.css"))
+      expect(_normalizeWebpackPath("/PATH/TO/node_modules/css-loader/index.js??ref--7-1!/PATH/TO/node_modules/postcss-loader/lib/index.js??ref--7-2!/PATH/TO/src/bar/my-style.css"))
         .to.equal("/PATH/TO/src/bar/my-style.css");
     });
     // tslint:enable max-line-length

--- a/test/lib/actions/sizes.spec.ts
+++ b/test/lib/actions/sizes.spec.ts
@@ -44,12 +44,6 @@ const patchAction = (name) => (instance) => {
   // Patch internal data based on baseName keys.
   // **Note**: Patch modules **first** since memoized, then used by assets.
   instance._modules = instance.modules.map((mod) => {
-    // Remove `name` field, as it can be any of the form:
-    // - v1, v2: "/PATH/TO/ROOT/~/pkg/index.js"
-    // - v3: "/PATH/TO/ROOT/node_modules/pkg/index.js"
-    // - v4: "./node_modules/pkg/index.js"
-    delete mod.name;
-
     const patched = PATCHED_MODS[mod.baseName];
     return patched ? { ...mod, ...patched } : mod;
   });

--- a/test/lib/actions/sizes.spec.ts
+++ b/test/lib/actions/sizes.spec.ts
@@ -44,6 +44,12 @@ const patchAction = (name) => (instance) => {
   // Patch internal data based on baseName keys.
   // **Note**: Patch modules **first** since memoized, then used by assets.
   instance._modules = instance.modules.map((mod) => {
+    // Remove `name` field, as it can be any of the form:
+    // - v1, v2: "/PATH/TO/ROOT/~/pkg/index.js"
+    // - v3: "/PATH/TO/ROOT/node_modules/pkg/index.js"
+    // - v4: "./node_modules/pkg/index.js"
+    delete mod.name;
+
     const patched = PATCHED_MODS[mod.baseName];
     return patched ? { ...mod, ...patched } : mod;
   });


### PR DESCRIPTION
- Use the `name` field to better normalize `identifier` and remove trailing stuff in `path.js 0`.
- Sets up using `_normalizeWebpackPath(identifier) === normalizedId;` to check if something is likely . generated / synthetic.
- **NOTE**:  Can have more `basePath` duplicates now (because loader stuff stripped).