### PR TITLE
[WIP] BUG: hidden app roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,8 +486,8 @@ Other tools that inspect Webpack bundles:
 
 [npm_img]: https://badge.fury.io/js/inspectpack.svg
 [npm_site]: http://badge.fury.io/js/inspectpack
-[trav_img]: https://api.travis-ci.org/FormidableLabs/inspectpack.svg
-[trav_site]: https://travis-ci.org/FormidableLabs/inspectpack
+[trav_img]: https://api.travis-ci.com/FormidableLabs/inspectpack.svg
+[trav_site]: https://travis-ci.com/FormidableLabs/inspectpack
 [appveyor_img]: https://ci.appveyor.com/api/projects/status/github/formidablelabs/inspectpack?branch=master&svg=true
 [appveyor_site]: https://ci.appveyor.com/project/FormidableLabs/inspectpack
 [cov]: https://codecov.io

--- a/src/lib/actions/base.ts
+++ b/src/lib/actions/base.ts
@@ -51,6 +51,9 @@ export const _isNodeModules = (name: string): boolean => nodeModulesParts(name).
 // First, strip off anything before a `?` and `!`:
 // - `REMOVE?KEEP`
 // - `REMOVE!KEEP`
+//
+// TODO(106): Revise code and tests for `fullPath`.
+// https://github.com/FormidableLabs/inspectpack/issues/106
 export const _normalizeWebpackPath = (identifier: string, name?: string): string => {
   const bangLastIdx = identifier.lastIndexOf("!");
   const questionLastIdx = identifier.lastIndexOf("?");
@@ -90,6 +93,9 @@ export const _normalizeWebpackPath = (identifier: string, name?: string): string
       candidate = candidate.substr(0, nameLastIdx + name.length);
     }
   }
+
+  // Naive heuristic: remove known starting webpack tokens.
+  candidate = candidate.replace(/^(multi |ignored )/, "");
 
   return candidate;
 };

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -40,7 +40,6 @@ import {
 export const _packageRoots = (mods: IModule[]): Promise<string[]> => {
   const depRoots: string[] = [];
   const candidateAppRoots: string[] = [];
-
   // Iterate node_modules modules and add to list of roots.
   mods
     .filter((mod) => mod.isNodeModules)
@@ -54,6 +53,12 @@ export const _packageRoots = (mods: IModule[]): Promise<string[]> => {
         depRoots.push(candidate);
       }
     });
+
+  // If there are no dependency roots, then we don't care about dependencies
+  // and don't need to find any application roots. Short-ciruit.
+  if (!depRoots.length) {
+    return Promise.resolve(depRoots);
+  }
 
   // Now, the tricky part. Find "hidden roots" that don't have `node_modules`
   // in the path, but still have a `package.json`. To limit the review of this
@@ -94,7 +99,7 @@ export const _packageRoots = (mods: IModule[]): Promise<string[]> => {
     candidateAppRoots.map((appRoot) => exists(join(appRoot, "package.json")))
   ).then((rootExists) => {
     const appRoots = candidateAppRoots.filter((r, i) => rootExists[i]);
-    console.log("TODO HERE", { rootExists, appRoots });
+    console.log("TODO HERE", { candidateAppRoots, rootExists, appRoots });
 
     // TODO HERE:
     // - [ ] Convert to async and actually check the potential app roots.

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -14,13 +14,13 @@ import { exists, toPosixPath } from "../util/files";
 import { serial } from "../util/promise";
 import { numF, sort } from "../util/strings";
 import {
+  _normalizeWebpackPath,
   Action,
   IAction,
   IActionConstructor,
   ITemplate,
   nodeModulesParts,
   Template,
-  _normalizeWebpackPath,
 } from "./base";
 
 // Node.js `require`-compliant sorted order.
@@ -79,6 +79,8 @@ export const _packageRoots = (mods: IModule[]): Promise<string[]> => {
       // - [ ] TODO: Cannot be shorter than shortest depRoot
 
       // Start at full path.
+      // TODO(106): Revise code and tests for `fullPath`.
+      // https://github.com/FormidableLabs/inspectpack/issues/106
       let curPath: string|null = _normalizeWebpackPath(mod.identifier);
 
       // Iterate parts.
@@ -109,7 +111,6 @@ export const _packageRoots = (mods: IModule[]): Promise<string[]> => {
 
     // TODO: ISSUE: query paths in identifier...
     // TODO: HERE -- probably best solution: split on ?! and take after. Simple split.
-    // TODO: TICKET -- do more properly with fullPath branch (still have ignored, multi things)
 
     // - [ ] TODO(TEST): synthetic mod.
     // - [ ] TODO(TEST): Loader paths in identifier.
@@ -202,7 +203,7 @@ const modulesByPackageNameByPackagePath = (
 
     // Insert package path. (All the different installs of package).
     const pkgMap = modsMap[pkgName];
-    const modParts = mod.identifier.split(sep);
+    const modParts = _normalizeWebpackPath(mod.identifier).split(sep);
     const nmIndex = modParts.lastIndexOf("node_modules");
     const pkgPath = modParts
       // Remove base name path suffix.

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -107,10 +107,7 @@ export const _packageRoots = (mods: IModule[]): Promise<string[]> => {
     const appRoots = candidateAppRoots.filter((_, i) => rootExists[i]);
 
     // - [ ] TODO(TEST): synthetic mod.
-    return _requireSort([].concat(
-      depRoots,
-      appRoots,
-    ));
+    return _requireSort(depRoots.concat(appRoots));
   });
 };
 

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -301,7 +301,8 @@ class Versions extends Action {
 
     // Infer the absolute paths to the package roots.
     const pkgRoots = packagesRoots(mods);
-    // // TODO: REMOVE
+    // TODO: REMOVE
+    // TODO: Need to infer this "for realz"
     // pkgRoots.push(
     //   "/Users/rye/scm/fmd/inspectpack/test/fixtures/hidden-app-roots/packages/hidden-app"
     // );

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -333,8 +333,10 @@ class Versions extends Action {
     const pkgsFilter = allPackages(mods);
 
     // Recursively read in dependencies.
+    //
     // However, since package roots rely on a properly seeded cache from earlier
-    // runs with a higher-up, valid traversal path, we start bottom up.
+    // runs with a higher-up, valid traversal path, we start bottom up in serial
+    // rather than executing different roots in parallel.
     //
     // TODO(ROOTS): Test this is the correct order for traversal.
     let allDeps: Array<IDependencies | null>;

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -105,8 +105,11 @@ export const _packageRoots = (mods: IModule[]): Promise<string[]> => {
     candidateAppRoots.map((appRoot) => exists(join(appRoot, "package.json"))),
   ).then((rootExists) => {
     const appRoots = candidateAppRoots.filter((_, i) => rootExists[i]);
+    console.log("TODO HERE", { depRoots, candidateAppRoots, appRoots });
+    // TODO: ISSUE: query paths in identifier...
 
     // - [ ] TODO(TEST): synthetic mod.
+    // - [ ] TODO(TEST): Loader paths in identifier.
     // - [ ] TODO(TEST): Regression test for duplicate packages showing
     //       up in issue reproduction respository.
     //       `$ yarn workspace @haaretz/haaretz.co.il build`

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -355,7 +355,14 @@ const getAssetData = (
           const dataVers = data.packages[name][version] = data.packages[name][version] || {};
           const dataObj = dataVers[relPath] = dataVers[relPath] || {};
           dataObj.skews = (dataObj.skews || []).concat(depsForPkgVers[filePath].skews);
-          dataObj.modules = (dataObj.modules || []).concat(modules);
+
+          dataObj.modules = dataObj.modules || [];
+          // Add _new, unique_ modules.
+          // Note that `baseName` might have multiple matches for duplicate installs, but
+          // `fileName` won't.
+          const newMods = modules
+            .filter((newMod) => !dataObj.modules.some((mod) => mod.fileName === newMod.fileName));
+          dataObj.modules = dataObj.modules.concat(newMods);
         });
       });
     });

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -37,7 +37,7 @@ import {
  * @param mods {IModule[]} list of modules.
  * @returns {string[]} list of package roots.
  */
-const packagesRoots = (mods: IModule[]): string[] => {
+export const _packageRoots = (mods: IModule[]): string[] => {
   const roots: string[] = [];
 
   // Iterate node_modules modules and add to list of roots.
@@ -54,6 +54,7 @@ const packagesRoots = (mods: IModule[]): string[] => {
       }
     });
 
+  // TODO: CHECK NODE REQUIRE ORDER!!!
   return roots.sort();
 };
 
@@ -304,7 +305,7 @@ class Versions extends Action {
     const pkgMap = {};
 
     // Infer the absolute paths to the package roots.
-    const pkgRoots = packagesRoots(mods);
+    const pkgRoots = _packageRoots(mods);
     // TODO: REMOVE
     // - [ ] TODO: Need to infer this "for realz"
     // - [ ] TODO: Need to sort these things in order of `require` resolution. (HINT: REVERSE)

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -107,6 +107,8 @@ export const _packageRoots = (mods: IModule[]): Promise<string[]> => {
     const appRoots = candidateAppRoots.filter((_, i) => rootExists[i]);
     console.log("TODO HERE", { depRoots, candidateAppRoots, appRoots });
     // TODO: ISSUE: query paths in identifier...
+    // TODO: HERE -- probably best solution: split on ?! and take after. Simple split.
+    // TODO: TICKET -- do more properly with fullPath branch (still have ignored, multi things)
 
     // - [ ] TODO(TEST): synthetic mod.
     // - [ ] TODO(TEST): Loader paths in identifier.

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -61,6 +61,10 @@ export const _packageRoots = (mods: IModule[]): string[] => {
   // project had a `package.json` that got flattened.
 
   // TODO HERE:
+  // - [ ] Maybe rename to `depRoots` above and `appRoots` here? (Then combine)
+  // - [ ] Get potential list of roots to check in order for a `package.json`
+  // - [ ] Convert to async and actually check the potential app roots.
+  //
   // TODO(IDEA): More complete.
   // 1. Identify `node_modules` roots,
   // 2. Walk down checking non-NodeMods `package.json` along the way from source files

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -301,7 +301,19 @@ class Versions extends Action {
 
     // Infer the absolute paths to the package roots.
     const pkgRoots = packagesRoots(mods);
+    // TODO: REMOVE
+    pkgRoots.push(
+      "/Users/rye/scm/fmd/inspectpack/test/fixtures/hidden-app-roots/packages/hidden-app"
+    );
     console.log("TODO HERE", { pkgRoots })
+
+    // TODO: NOTE
+    // - `dependencies()` can share a package map cache.
+    // - We can sort the `pkgRoots` to do "more root" first, and less root later.
+    // - Possibly using the cache we can give "more" options to traverse up beyond current root?
+    //
+    // TODO: Also
+    // - [ ] Throw error on not found package?
 
     // If we don't have a package root, then we have no dependencies in the
     // bundle and we can short circuit.

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -301,6 +301,7 @@ class Versions extends Action {
 
     // Infer the absolute paths to the package roots.
     const pkgRoots = packagesRoots(mods);
+    console.log("TODO HERE", { pkgRoots })
 
     // If we don't have a package root, then we have no dependencies in the
     // bundle and we can short circuit.

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -301,11 +301,11 @@ class Versions extends Action {
 
     // Infer the absolute paths to the package roots.
     const pkgRoots = packagesRoots(mods);
-    // TODO: REMOVE
-    pkgRoots.push(
-      "/Users/rye/scm/fmd/inspectpack/test/fixtures/hidden-app-roots/packages/hidden-app"
-    );
-    console.log("TODO HERE", { pkgRoots })
+    // // TODO: REMOVE
+    // pkgRoots.push(
+    //   "/Users/rye/scm/fmd/inspectpack/test/fixtures/hidden-app-roots/packages/hidden-app"
+    // );
+    // console.log("TODO HERE", { pkgRoots })
 
     // TODO: NOTE
     // - `dependencies()` can share a package map cache.

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -84,20 +84,33 @@ export const _packageRoots = (mods: IModule[]): Promise<string[]> => {
       }
     });
 
-  // TODO HERE:
-  // - [ ] Convert to async and actually check the potential app roots.
-  // - [ ] Combine, then sort `depRoots` and `appRoots`.
-  // - [ ] Get potential list of roots to check in order for a `package.json`
-  // - [ ] TODO(TEST): synthetic mod.
+  // Check all the potential application roots for the presence of a
+  // `package.json` file. This is a bit of disk I/O but saves us later I/O and
+  // processing to not have false roots in the list of potential roots.
   //
-  // TODO(IDEA): More complete.
-  // 1. Identify `node_modules` roots,
-  // 2. Walk down checking non-NodeMods `package.json` along the way from source files
-  // TODO(IDEA): Hacky. If match "*/packages/*", then do a "packages/*/package.json" check.
+  // We fortunately _don't_ need to check dependencies roots, because anything
+  // with a `node_modules` directory in it **must** have a `package.json`.
+  return Promise.all(
+    appRoots.map((appRoot) => exists(join(appRoot, "package.json")))
+  ).then((rootExists) => {
+    const foundAppRoots = appRoots.filter((r, i) => rootExists[i]);
+    console.log("TODO HERE", { rootExists, foundAppRoots });
 
-  // - [ ] TODO: CHECK NODE REQUIRE ORDER!!!
-  // - [ ] TODO: ADD TESTS FOR NODE REQUIRE ORDER!!!
-  return Promise.resolve(depRoots.sort());
+    // TODO HERE:
+    // - [ ] Convert to async and actually check the potential app roots.
+    // - [ ] Combine, then sort `depRoots` and `appRoots`.
+    // - [ ] Get potential list of roots to check in order for a `package.json`
+    // - [ ] TODO(TEST): synthetic mod.
+    //
+    // TODO(IDEA): More complete.
+    // 1. Identify `node_modules` roots,
+    // 2. Walk down checking non-NodeMods `package.json` along the way from source files
+    // TODO(IDEA): Hacky. If match "*/packages/*", then do a "packages/*/package.json" check.
+
+    // - [ ] TODO: CHECK NODE REQUIRE ORDER!!!
+    // - [ ] TODO: ADD TESTS FOR NODE REQUIRE ORDER!!!
+    return depRoots.sort();
+  });
 };
 
 // Simple helper to get package name from a base name.

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -102,15 +102,15 @@ export const _packageRoots = (mods: IModule[]): Promise<string[]> => {
   // We fortunately _don't_ need to check dependencies roots, because anything
   // with a `node_modules` directory in it **must** have a `package.json`.
   return Promise.all(
-    candidateAppRoots.map((appRoot) => exists(join(appRoot, "package.json")))
+    candidateAppRoots.map((appRoot) => exists(join(appRoot, "package.json"))),
   ).then((rootExists) => {
-    const appRoots = candidateAppRoots.filter((r, i) => rootExists[i]);
+    const appRoots = candidateAppRoots.filter((_, i) => rootExists[i]);
 
     // - [ ] TODO(TEST): synthetic mod.
     return _requireSort([].concat(
       depRoots,
       appRoots,
-    ))
+    ));
   });
 };
 
@@ -365,12 +365,7 @@ class Versions extends Action {
       // TODO: REMOVE
       // - [ ] TODO: Need to infer this "for realz"
       // - [ ] TODO: Need to sort these things in order of `require` resolution. (HINT: REVERSE)
-      if (process.env.TEMP_ROOTS) {
-        pkgRoots.push(
-          "/Users/rye/scm/fmd/inspectpack/test/fixtures/hidden-app-roots/packages/hidden-app",
-        );
-      }
-
+      //
       // TODO: NOTE
       // - `dependencies()` can share a package map cache.
       // - We can sort the `pkgRoots` to do "more root" first, and less root later.

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -54,7 +54,20 @@ export const _packageRoots = (mods: IModule[]): string[] => {
       }
     });
 
-  // TODO: CHECK NODE REQUIRE ORDER!!!
+  // Now, the tricky part. Find "hidden roots" that don't have `node_modules`
+  // in the path, but still have a `package.json`. To limit the review of this
+  // we only check up to a pre-existing root above that _is_ a `node_modules`-
+  // based root, because that would have to exist if somewhere deeper in a
+  // project had a `package.json` that got flattened.
+
+  // TODO HERE:
+  // TODO(IDEA): More complete.
+  // 1. Identify `node_modules` roots,
+  // 2. Walk down checking non-NodeMods `package.json` along the way from source files
+  // TODO(IDEA): Hacky. If match "*/packages/*", then do a "packages/*/package.json" check.
+
+  // - [ ] TODO: CHECK NODE REQUIRE ORDER!!!
+  // - [ ] TODO: ADD TESTS FOR NODE REQUIRE ORDER!!!
   return roots.sort();
 };
 

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -88,8 +88,8 @@ export const _packageRoots = (mods: IModule[]): Promise<string[]> => {
           !depRoots.some((d) => !!curPath && curPath.indexOf(d) === 0)
         ) {
           curPath = null;
-        } else {
-          // Potential root.
+        } else if (candidateAppRoots.indexOf(curPath) === -1) {
+          // Add potential unique root.
           candidateAppRoots.push(curPath);
         }
       }
@@ -107,9 +107,13 @@ export const _packageRoots = (mods: IModule[]): Promise<string[]> => {
     const appRoots = candidateAppRoots.filter((_, i) => rootExists[i]);
 
     // - [ ] TODO(TEST): synthetic mod.
-    // - [ ] TODO(TEST/BUG): Getting **lots** of duplicate packages showing
+    // - [ ] TODO(TEST): Regression test for duplicate packages showing
     //       up in issue reproduction respository.
     //       `$ yarn workspace @haaretz/haaretz.co.il build`
+    // console.log("TODO HERE ROOTS", JSON.stringify({
+    //   depRoots,
+    //   appRoots,
+    // }, null, 2));
     return _requireSort(depRoots.concat(appRoots));
   });
 };

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -39,7 +39,7 @@ import {
  */
 export const _packageRoots = (mods: IModule[]): Promise<string[]> => {
   const depRoots: string[] = [];
-  const appRoots: string[] = [];
+  const candidateAppRoots: string[] = [];
 
   // Iterate node_modules modules and add to list of roots.
   mods
@@ -79,7 +79,7 @@ export const _packageRoots = (mods: IModule[]): Promise<string[]> => {
           curPath = null;
         } else {
           // Potential root.
-          appRoots.push(curPath);
+          candidateAppRoots.push(curPath);
         }
       }
     });
@@ -91,10 +91,10 @@ export const _packageRoots = (mods: IModule[]): Promise<string[]> => {
   // We fortunately _don't_ need to check dependencies roots, because anything
   // with a `node_modules` directory in it **must** have a `package.json`.
   return Promise.all(
-    appRoots.map((appRoot) => exists(join(appRoot, "package.json")))
+    candidateAppRoots.map((appRoot) => exists(join(appRoot, "package.json")))
   ).then((rootExists) => {
-    const foundAppRoots = appRoots.filter((r, i) => rootExists[i]);
-    console.log("TODO HERE", { rootExists, foundAppRoots });
+    const appRoots = candidateAppRoots.filter((r, i) => rootExists[i]);
+    console.log("TODO HERE", { rootExists, appRoots });
 
     // TODO HERE:
     // - [ ] Convert to async and actually check the potential app roots.

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -22,6 +22,12 @@ import {
   Template,
 } from "./base";
 
+// Node.js `require`-compliant sorted order.
+// TODO: Lots of tests!!!
+export const _requireSort = (vals: string[]) => {
+  return vals.sort();
+};
+
 /**
  * Webpack projects can have multiple "roots" of `node_modules` that can be
  * the source of installed versions, including things like:
@@ -99,22 +105,12 @@ export const _packageRoots = (mods: IModule[]): Promise<string[]> => {
     candidateAppRoots.map((appRoot) => exists(join(appRoot, "package.json")))
   ).then((rootExists) => {
     const appRoots = candidateAppRoots.filter((r, i) => rootExists[i]);
-    console.log("TODO HERE", { candidateAppRoots, rootExists, appRoots });
 
-    // TODO HERE:
-    // - [ ] Convert to async and actually check the potential app roots.
-    // - [ ] Combine, then sort `depRoots` and `appRoots`.
-    // - [ ] Get potential list of roots to check in order for a `package.json`
     // - [ ] TODO(TEST): synthetic mod.
-    //
-    // TODO(IDEA): More complete.
-    // 1. Identify `node_modules` roots,
-    // 2. Walk down checking non-NodeMods `package.json` along the way from source files
-    // TODO(IDEA): Hacky. If match "*/packages/*", then do a "packages/*/package.json" check.
-
-    // - [ ] TODO: CHECK NODE REQUIRE ORDER!!!
-    // - [ ] TODO: ADD TESTS FOR NODE REQUIRE ORDER!!!
-    return depRoots.sort();
+    return _requireSort([].concat(
+      depRoots,
+      appRoots,
+    ))
   });
 };
 

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -73,6 +73,8 @@ export const _packageRoots = (mods: IModule[]): string[] => {
       while (curPath = curPath && dirname(curPath)) {
         // At a known root.
         if (depRoots.indexOf(curPath) > -1) {
+          // - [ ] TODO: Revise return logic.
+          // - [ ] TODO: Combine with conditional below.
           curPath = null;
           break;
         }
@@ -81,7 +83,7 @@ export const _packageRoots = (mods: IModule[]): string[] => {
         const haveCommonRoot = !!depRoots.filter((d) => curPath && curPath.indexOf(d) === 0).length;
         if (!haveCommonRoot) {
           curPath = null;
-          return;
+          break;
         }
 
         // Potential root.

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -107,6 +107,9 @@ export const _packageRoots = (mods: IModule[]): Promise<string[]> => {
     const appRoots = candidateAppRoots.filter((_, i) => rootExists[i]);
 
     // - [ ] TODO(TEST): synthetic mod.
+    // - [ ] TODO(TEST/BUG): Getting **lots** of duplicate packages showing
+    //       up in issue reproduction respository.
+    //       `$ yarn workspace @haaretz/haaretz.co.il build`
     return _requireSort(depRoots.concat(appRoots));
   });
 };

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -330,8 +330,14 @@ class Versions extends Action {
     const pkgsFilter = allPackages(mods);
 
     // Recursively read in dependencies.
+    // However, since package roots rely on a properly seeded cache from earlier
+    // runs with a higher-up, valid traversal path, we start bottom up.
+    //
+    // TODO(ROOTS): Test this is the correct order for traversal.
     let allDeps: Array<IDependencies | null>;
-    return Promise.all(pkgRoots.map((pkgRoot) => dependencies(pkgRoot, pkgsFilter, pkgMap)))
+    return Promise.all(
+      pkgRoots.map((pkgRoot) => dependencies(pkgRoot, pkgsFilter, pkgMap)),
+    )
       // Capture deps.
       .then((all) => { allDeps = all; })
       // Check dependencies and validate.

--- a/src/lib/util/dependencies.ts
+++ b/src/lib/util/dependencies.ts
@@ -146,19 +146,17 @@ const _findPackage = ({
   filePath,
   name,
   pkgMap,
-  rootPath,
 }: {
   filePath: string,
   name: string,
   pkgMap: INpmPackageMap,
-  rootPath: string,
 }): {
   isFlattened: boolean,
   pkgPath: string | null;
   pkgObj: INpmPackage | null;
 } => {
   // Incoming root.
-  const resolvedRoot = resolve(rootPath);
+  const resolvedRoot = resolve(filePath);
 
   // We now check the existing package map which, if iterating in correct
   // directory order, should already have higher up roots that may contain
@@ -172,8 +170,8 @@ const _findPackage = ({
     .map((k) => resolve(dirname(k)))
     // Limit to those that are a higher up directory from our root, which
     // is fair game by Node.js `require` resolution rules, and not the current
-    // rootPath because that already failed.
-    .filter((p) => p !== resolvedRoot && rootPath.indexOf(p) === 0);
+    // root because that already failed.
+    .filter((p) => p !== resolvedRoot && resolvedRoot.indexOf(p) === 0);
 
   const roots = [resolvedRoot].concat(cachedRoots);
 
@@ -223,14 +221,12 @@ const _recurseDependencies = ({
   names,
   pkgMap,
   pkgsFilter,
-  rootPath,
 }: {
   filePath: string,
   foundMap?: { [filePath: string]: { [name: string]: IDependencies | null } },
   names: string[],
   pkgMap: INpmPackageMap,
   pkgsFilter?: string[],
-  rootPath: string,
 }): IDependencies[] => {
   // Build up cache.
   const _foundMap = foundMap || {};
@@ -242,12 +238,12 @@ const _recurseDependencies = ({
     // Inflated current level.
     .map((name): { pkg: IDependencies, pkgNames: string[] } | null => {
       // Find actual location.
-      const { isFlattened, pkgPath, pkgObj } = _findPackage({ filePath, name, rootPath, pkgMap });
+      const { isFlattened, pkgPath, pkgObj } = _findPackage({ filePath, name, pkgMap });
 
       // Short-circuit on not founds.
       if (pkgPath === null || pkgObj === null) {
         // TODO: Throw if not found?
-        // console.log("TODO HERE MISS", { filePath, name, rootPath, isFlattened, pkgPath, pkgObj });
+        // console.log("TODO HERE MISS", { filePath, name, isFlattened, pkgPath, pkgObj });
         return null;
       }
 
@@ -296,7 +292,6 @@ const _recurseDependencies = ({
           names: pkgNames,
           pkgMap,
           pkgsFilter,
-          rootPath,
         });
       }
 
@@ -475,7 +470,6 @@ export const dependencies = (
           names,
           pkgMap,
           pkgsFilter,
-          rootPath: filePath,
         }),
         filePath,
         name: rootPkg.name || "ROOT",

--- a/src/lib/util/dependencies.ts
+++ b/src/lib/util/dependencies.ts
@@ -163,25 +163,24 @@ export const _findPackage = ({
   pkgPath: string | null;
   pkgObj: INpmPackage | null;
 } => {
-  // Incoming root.
-  const resolvedRoot = filePath;
-
   // We now check the existing package map which, if iterating in correct
   // directory order, should already have higher up roots that may contain
   // `node_modules` **within** the `require` resolution rules that would
   // naturally be the "selected" module.
   //
   // Fixes https://github.com/FormidableLabs/inspectpack/issues/10
-  // TODO(TEST): Add _multiple_ upper roots and make sure we choose the correct one.
+  //
+  // - [ ] TODO(TEST): Add _multiple_ upper roots and make sure we choose the correct one.
+  // - [ ] TODO(ROOTS): Need to **sort** correctly according to resolution for iteration
   const cachedRoots = Object.keys(pkgMap)
     // Get directories.
     .map((k) => dirname(k))
     // Limit to those that are a higher up directory from our root, which
     // is fair game by Node.js `require` resolution rules, and not the current
     // root because that already failed.
-    .filter((p) => p !== resolvedRoot && resolvedRoot.indexOf(p) === 0);
+    .filter((p) => p !== filePath && filePath.indexOf(p) === 0);
 
-  const roots = [resolvedRoot].concat(cachedRoots);
+  const roots = [filePath].concat(cachedRoots);
 
   // Iterate down potential paths.
   // If we find it as _first_ result, then it hasn't been flattened.

--- a/src/lib/util/dependencies.ts
+++ b/src/lib/util/dependencies.ts
@@ -465,11 +465,6 @@ export const dependencies = (
       const rootPkg = pkgMap[join(filePath, "package.json")];
       if (rootPkg === null || rootPkg === undefined) { return null; }
 
-      // console.log("TODO HERE deps", JSON.stringify({
-      //   filePath,
-      //   pkgMap,
-      // }, null, 2));
-
       // Have a real package, start inflating.
       // Include devDependencies in root of project because _could_ end up in
       // real final bundle.

--- a/src/lib/util/dependencies.ts
+++ b/src/lib/util/dependencies.ts
@@ -106,7 +106,7 @@ export const readPackages = (
     // Read root package.
     .then(() => readPackage(join(path, "package.json"), _cache))
     // Stash package.
-    .then((pkg) => { _pkg = pkg })
+    .then((pkg) => { _pkg = pkg; })
     // Read next level of directories.
     .then(() => readDir(join(path, "node_modules")))
     // Add extra directories for scoped packages.

--- a/src/lib/util/dependencies.ts
+++ b/src/lib/util/dependencies.ts
@@ -123,6 +123,14 @@ export const readPackages = (
       dirs
         // Filter to known packages.
         .filter(isIncludedPkg)
+        .map((dir) => {
+          // console.log("TODO HERE NEXT LEVEL", JSON.stringify({
+          //   path,
+          //   dir,
+          // }, null, 2))
+
+          return dir;
+        })
         // Recurse
         .map((dir) => readPackages(join(path, "node_modules", dir), pkgsFilter, _cache)),
     ))
@@ -456,6 +464,11 @@ export const dependencies = (
       // Short-circuit empty package.
       const rootPkg = pkgMap[join(filePath, "package.json")];
       if (rootPkg === null || rootPkg === undefined) { return null; }
+
+      // console.log("TODO HERE deps", JSON.stringify({
+      //   filePath,
+      //   pkgMap,
+      // }, null, 2));
 
       // Have a real package, start inflating.
       // Include devDependencies in root of project because _could_ end up in

--- a/src/lib/util/dependencies.ts
+++ b/src/lib/util/dependencies.ts
@@ -1,4 +1,4 @@
-import { dirname, join, resolve } from "path";
+import { dirname, join } from "path";
 import { readDir, readJson, toPosixPath } from "./files";
 
 export interface INpmPackageBase {
@@ -142,7 +142,7 @@ export const _resolvePackageMap = (
     {},
   ));
 
-const _findPackage = ({
+export const _findPackage = ({
   filePath,
   name,
   pkgMap,
@@ -156,7 +156,7 @@ const _findPackage = ({
   pkgObj: INpmPackage | null;
 } => {
   // Incoming root.
-  const resolvedRoot = resolve(filePath);
+  const resolvedRoot = filePath;
 
   // We now check the existing package map which, if iterating in correct
   // directory order, should already have higher up roots that may contain
@@ -167,7 +167,7 @@ const _findPackage = ({
   // TODO(TEST): Add _multiple_ upper roots and make sure we choose the correct one.
   const cachedRoots = Object.keys(pkgMap)
     // Get directories.
-    .map((k) => resolve(dirname(k)))
+    .map((k) => dirname(k))
     // Limit to those that are a higher up directory from our root, which
     // is fair game by Node.js `require` resolution rules, and not the current
     // root because that already failed.
@@ -184,7 +184,7 @@ const _findPackage = ({
     // shouldn't be too expensive.
     let curFilePath = filePath;
 
-    while (curRoot.length <= resolve(curFilePath).length) {
+    while (curRoot.length <= curFilePath.length) {
       // Check at this level.
       const pkgPath = join(curFilePath, "node_modules", name);
       const pkgJsonPath = join(pkgPath, "package.json");
@@ -209,7 +209,7 @@ const _findPackage = ({
     }
   }
 
-  return { isFlattened, pkgPath: null, pkgObj: null };
+  return { isFlattened: false, pkgPath: null, pkgObj: null };
 };
 
 // - Populates `pkgMap` with installed `package.json`s

--- a/src/lib/util/dependencies.ts
+++ b/src/lib/util/dependencies.ts
@@ -201,6 +201,34 @@ const _findPackage = ({
     isFlattened = true;
   }
 
+  // No match.
+  // We now check the existing package map which, if iterating in correct
+  // directory order, should already have higher up roots that may contain
+  // `node_modules` **within** the `require` resolution rules that would
+  // naturally be the "selected" module.
+  //
+  // Fixes https://github.com/FormidableLabs/inspectpack/issues/10
+  // TODO(TEST): Add _multiple_ upper roots and make sure we choose the correct one.
+  const otherRequireRoots = Object.keys(pkgMap)
+    // Get directories.
+    .map((k) => resolve(dirname(k)))
+    // Limit to those that are a higher up directory from our root, which
+    // is fair game by Node.js `require` resolution rules, and not the current
+    // rootPath because that already failed.
+    .filter((p) => p !== rootPath && rootPath.indexOf(p) === 0)
+
+  // TODO: REMOVE THIS? OR THROW ERROR?
+  // TODO HERE: Need to go further past resolvedRoot?
+  // TODO IDEA: The `pkgMap` **has** the actual data. Just need to infer / traverse it.
+  // TODO SIDE NOTE: `isFlattened` is going to be impacted by this though.
+  console.log("TODO HERE _findPackage MISS", {
+    otherRequireRoots,
+    // filePath,
+    // name,
+    // pkgMap,
+    rootPath,
+  });
+
   return { isFlattened, pkgPath: null, pkgObj: null };
 };
 

--- a/src/lib/util/promise.ts
+++ b/src/lib/util/promise.ts
@@ -1,0 +1,5 @@
+// Execute promises in serial.
+export const serial = (proms: Array<() => Promise<any>>) => proms.reduce(
+  (memo, prom) => memo.then((vals) => prom().then((val: any) => vals.concat(val))),
+  Promise.resolve([]),
+);

--- a/test/fixtures/config/scenarios.json
+++ b/test/fixtures/config/scenarios.json
@@ -8,5 +8,6 @@
   { "WEBPACK_CWD": "../../test/fixtures/multiple-chunks" },
   { "WEBPACK_CWD": "../../test/fixtures/scoped" },
   { "WEBPACK_CWD": "../../test/fixtures/tree-shaking" },
-  { "WEBPACK_CWD": "../../test/fixtures/multiple-resolved-no-duplicates" }
+  { "WEBPACK_CWD": "../../test/fixtures/multiple-resolved-no-duplicates" },
+  { "WEBPACK_CWD": "../../test/fixtures/hidden-app-roots" }
 ]

--- a/test/fixtures/hidden-app-roots/node_modules/different-foo/index.js
+++ b/test/fixtures/hidden-app-roots/node_modules/different-foo/index.js
@@ -1,0 +1,11 @@
+const { foo } = require("foo");
+const { car } = require("foo/car");
+
+module.exports = {
+  differentFoo() {
+    return foo();
+  },
+  car() {
+    return car();
+  }
+};

--- a/test/fixtures/hidden-app-roots/node_modules/different-foo/node_modules/foo/car.js
+++ b/test/fixtures/hidden-app-roots/node_modules/different-foo/node_modules/foo/car.js
@@ -1,0 +1,5 @@
+module.exports = {
+  car() {
+    return "I'm a car!";
+  }
+};

--- a/test/fixtures/hidden-app-roots/node_modules/different-foo/node_modules/foo/index.js
+++ b/test/fixtures/hidden-app-roots/node_modules/different-foo/node_modules/foo/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  foo() {
+    return "different foo";
+  }
+};

--- a/test/fixtures/hidden-app-roots/node_modules/different-foo/node_modules/foo/package.json
+++ b/test/fixtures/hidden-app-roots/node_modules/different-foo/node_modules/foo/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "foo",
+  "version": "3.3.3",
+  "description": "DUMMY MODULE, but different",
+  "main": "index.js"
+}

--- a/test/fixtures/hidden-app-roots/node_modules/different-foo/package.json
+++ b/test/fixtures/hidden-app-roots/node_modules/different-foo/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "different-foo",
+  "version": "1.1.1",
+  "description": "has contained, _different_ source version of foo",
+  "main": "index.js",
+  "dependencies": {
+    "foo": "^3.0.1"
+  }
+}

--- a/test/fixtures/hidden-app-roots/node_modules/foo/index.js
+++ b/test/fixtures/hidden-app-roots/node_modules/foo/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  foo() {
+    return "foo";
+  }
+};

--- a/test/fixtures/hidden-app-roots/node_modules/foo/package.json
+++ b/test/fixtures/hidden-app-roots/node_modules/foo/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "foo",
+  "version": "1.1.1",
+  "description": "DUMMY MODULE",
+  "main": "index.js"
+}

--- a/test/fixtures/hidden-app-roots/package.json
+++ b/test/fixtures/hidden-app-roots/package.json
@@ -2,6 +2,6 @@
   "name": "hidden-app-roots",
   "version": "1.2.3",
   "description": "DUMMY APP",
-  "main": "packages/hidden-app/index.js",
+  "main": "packages/hidden-app/src/index.js",
   "dependencies": {}
 }

--- a/test/fixtures/hidden-app-roots/package.json
+++ b/test/fixtures/hidden-app-roots/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "hidden-app-roots",
+  "version": "1.2.3",
+  "description": "DUMMY APP",
+  "main": "packages/hidden-app/index.js",
+  "dependencies": {}
+}

--- a/test/fixtures/hidden-app-roots/packages/hidden-app/package.json
+++ b/test/fixtures/hidden-app-roots/packages/hidden-app/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "package1",
+  "version": "1.1.1",
+  "description": "DUMMY PACKAGE",
+  "main": "index.js",
+  "dependencies": {
+    "different-foo": "^1.0.1",
+    "foo": "^1.0.0"
+  }
+}

--- a/test/fixtures/hidden-app-roots/packages/hidden-app/src/index.js
+++ b/test/fixtures/hidden-app-roots/packages/hidden-app/src/index.js
@@ -1,0 +1,8 @@
+/* eslint-disable no-console*/
+
+// both packages are flattened into root `node_modules`.
+const { foo } = require("foo");
+const { differentFoo } = require("different-foo");
+
+console.log("foo", foo());
+console.log("differentFoo", differentFoo());

--- a/test/fixtures/hidden-app-roots/webpack.config.js
+++ b/test/fixtures/hidden-app-roots/webpack.config.js
@@ -1,0 +1,16 @@
+/* globals __dirname */
+const { resolve } = require("path");
+
+module.exports = (webpack, config) => {
+  if (webpack) {
+    config.entry = {
+      bundle: "./packages/hidden-app/src/index.js"
+    };
+    config.resolve = config.resolve || {};
+    config.resolve.alias = Object.assign({}, config.resolve.alias, {
+      package2: resolve(__dirname, "packages/package2")
+    });
+  }
+
+  return config;
+};

--- a/test/fixtures/hidden-app-roots/webpack.config.js
+++ b/test/fixtures/hidden-app-roots/webpack.config.js
@@ -1,6 +1,3 @@
-/* globals __dirname */
-const { resolve } = require("path");
-
 module.exports = (webpack, config) => {
   if (webpack) {
     config.entry = {

--- a/test/fixtures/hidden-app-roots/webpack.config.js
+++ b/test/fixtures/hidden-app-roots/webpack.config.js
@@ -7,9 +7,6 @@ module.exports = (webpack, config) => {
       bundle: "./packages/hidden-app/src/index.js"
     };
     config.resolve = config.resolve || {};
-    config.resolve.alias = Object.assign({}, config.resolve.alias, {
-      package2: resolve(__dirname, "packages/package2")
-    });
   }
 
   return config;

--- a/test/fixtures/hidden-app-roots/webpack.config.js
+++ b/test/fixtures/hidden-app-roots/webpack.config.js
@@ -6,7 +6,6 @@ module.exports = (webpack, config) => {
     config.entry = {
       bundle: "./packages/hidden-app/src/index.js"
     };
-    config.resolve = config.resolve || {};
   }
 
   return config;

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -1,6 +1,7 @@
 import { join, resolve, sep } from "path";
 import {
   _packageName,
+  _packageRoots,
   create,
   IVersionsData,
   IVersionsMeta,
@@ -878,6 +879,45 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
 
     // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
     it("displays versions skews correctly for hidden app roots"); // TODO IMPLEMENT
+  });
+
+  describe("_packageRoots", () => {
+    it("handles base cases", () => {
+      expect(_packageRoots([])).to.eql([]);
+    });
+
+    it("handles no node_modules cases", () => {
+      expect(_packageRoots([
+        {
+          identifier: resolve("/my-app/src/baz/index.js"),
+          isNodeModules: false,
+        },
+        {
+          identifier: resolve("/my-app/src/baz/bug.js"),
+          isNodeModules: false,
+        },
+      ])).to.eql([]);
+    });
+
+    it("handles simple cases", () => {
+      expect(_packageRoots([
+        {
+          identifier: resolve("/my-app/src/baz/index.js"),
+          isNodeModules: false,
+        },
+        {
+          identifier: resolve("/my-app/node_modules/foo/index.js"),
+          isNodeModules: true,
+        },
+        {
+          identifier: resolve("/my-app/node_modules/foo/node_modules/bug/bug.js"),
+          isNodeModules: true,
+        },
+      ])).to.eql([
+        resolve("/my-app"),
+      ]);
+    });
+
   });
 
   describe("_packageName", () => {

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -632,6 +632,23 @@ describe("lib/actions/versions", () => {
             console.log("TODO HERE -- ASSERTS"); // tslint:disable-line no-console
           });
       });
+
+      // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
+      it.skip("displays versions skews correctly for hidden app roots with empty node_modules", () => { // TODO UNSKIP
+        const curFixtures = fixtureDirs["test/fixtures/hidden-app-roots"];
+        // Add empty `node_modules` to hit different code path.
+        curFixtures.packages["hidden-app"].node_modules = {};
+
+        mock({
+          "test/fixtures/hidden-app-roots": curFixtures,
+        });
+
+        return hiddenAppRootsInstance.getData()
+          .then((data) => {
+            expect(data).to.have.keys("meta", "assets");
+            console.log("TODO -- SAME ASSERTS AS ABOVE"); // tslint:disable-line no-console
+          });
+      });
     });
   });
 

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -599,7 +599,7 @@ describe("lib/actions/versions", () => {
       });
 
       // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
-      it.skip("displays versions skews correctly for hidden app roots", () => { // TODO UNSKIP
+      (process.env.TEMP_ROOTS ? it.only : it.skip)("displays versions skews correctly for hidden app roots", () => { // TODO UNSKIP
         mock({
           "test/fixtures/hidden-app-roots": fixtureDirs["test/fixtures/hidden-app-roots"],
         });

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -882,12 +882,11 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
   });
 
   describe("_packageRoots", () => {
-    it("handles base cases", () => {
-      expect(_packageRoots([])).to.eql([]);
-    });
+    it("handles base cases", () => _packageRoots([]).then((pkgRoots) => {
+      expect(pkgRoots).to.eql([]);
+    }));
 
-    it("handles no node_modules cases", () => {
-      expect(_packageRoots([
+    it("handles no node_modules cases", () => _packageRoots([
         {
           identifier: resolve("/my-app/src/baz/index.js"),
           isNodeModules: false,
@@ -896,27 +895,29 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
           identifier: resolve("/my-app/src/baz/bug.js"),
           isNodeModules: false,
         },
-      ])).to.eql([]);
-    });
+      ])
+      .then((pkgRoots) => {
+       expect(pkgRoots).to.eql([]);
+    }));
 
-    it("handles simple cases", () => {
-      expect(_packageRoots([
-        {
-          identifier: resolve("/my-app/src/baz/index.js"),
-          isNodeModules: false,
-        },
-        {
-          identifier: resolve("/my-app/node_modules/foo/index.js"),
-          isNodeModules: true,
-        },
-        {
-          identifier: resolve("/my-app/node_modules/foo/node_modules/bug/bug.js"),
-          isNodeModules: true,
-        },
-      ])).to.eql([
+    it("handles simple cases", () => _packageRoots([
+      {
+        identifier: resolve("/my-app/src/baz/index.js"),
+        isNodeModules: false,
+      },
+      {
+        identifier: resolve("/my-app/node_modules/foo/index.js"),
+        isNodeModules: true,
+      },
+      {
+        identifier: resolve("/my-app/node_modules/foo/node_modules/bug/bug.js"),
+        isNodeModules: true,
+      },
+    ]).then((pkgRoots) => {
+      expect(pkgRoots).to.eql([
         resolve("/my-app"),
       ]);
-    });
+    }));
 
     // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
     // TODO UNSKIP
@@ -947,10 +948,12 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
         },
       ];
 
-      expect(_packageRoots(mods)).to.eql([
-        appRoot,
-        `${appRoot}/packages/hidden-app`,
-      ]);
+      return _packageRoots(mods).then((pkgRoots) => {
+        expect(pkgRoots).to.eql([
+          appRoot,
+          `${appRoot}/packages/hidden-app`,
+        ]);
+      });
     });
   });
 

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -612,14 +612,14 @@ describe("lib/actions/versions", () => {
                 num: 2,
               },
               files: {
-                num: 2,
+                num: 3,
               },
               installed: {
                 num: 2,
               },
               packageRoots: [
                 resolve(__dirname, "../../fixtures/hidden-app-roots"),
-                // TODO: resolve(__dirname, "../../fixtures/hidden-app-roots/packages/hidden-app"),
+                resolve(__dirname, "../../fixtures/hidden-app-roots/packages/hidden-app"),
               ],
               packages: {
                 num: 1,
@@ -629,12 +629,24 @@ describe("lib/actions/versions", () => {
               },
             }));
 
-            console.log("TODO HERE -- ASSERTS"); // tslint:disable-line no-console
+            let expectProp;
+
+            expectProp = expect(data).to.have.nested.property(
+              "assets.bundle\\.js.packages.foo.1\\.1\\.1.\\.\\./\\.\\./node_modules/foo",
+            );
+            expectProp.to.have.property("skews").that.has.length(1);
+            expectProp.to.have.property("modules").that.has.length(1);
+
+            expectProp = expect(data).to.have.nested.property(
+              "assets.bundle\\.js.packages.foo.3\\.3\\.3.\\.\\./\\.\\./node_modules/different-foo/node_modules/foo",
+            );
+            expectProp.to.have.property("skews").that.has.length(1);
+            expectProp.to.have.property("modules").that.has.length(2);
           });
       });
 
       // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
-      it.skip("displays versions skews correctly for hidden app roots with empty node_modules", () => { // TODO UNSKIP
+      (process.env.TEMP_ROOTS ? it.only : it.skip)("displays versions skews correctly for hidden app roots with empty node_modules", () => { // TODO UNSKIP
         const curFixtures = fixtureDirs["test/fixtures/hidden-app-roots"];
         // Add empty `node_modules` to hit different code path.
         curFixtures.packages["hidden-app"].node_modules = {};
@@ -646,7 +658,41 @@ describe("lib/actions/versions", () => {
         return hiddenAppRootsInstance.getData()
           .then((data) => {
             expect(data).to.have.keys("meta", "assets");
-            console.log("TODO -- SAME ASSERTS AS ABOVE"); // tslint:disable-line no-console
+            expect(data).to.have.property("meta").that.eql(merge(EMPTY_VERSIONS_DATA.meta, {
+              depended: {
+                num: 2,
+              },
+              files: {
+                num: 3,
+              },
+              installed: {
+                num: 2,
+              },
+              packageRoots: [
+                resolve(__dirname, "../../fixtures/hidden-app-roots"),
+                resolve(__dirname, "../../fixtures/hidden-app-roots/packages/hidden-app"),
+              ],
+              packages: {
+                num: 1,
+              },
+              resolved: {
+                num: 2,
+              },
+            }));
+
+            let expectProp;
+
+            expectProp = expect(data).to.have.nested.property(
+              "assets.bundle\\.js.packages.foo.1\\.1\\.1.\\.\\./\\.\\./node_modules/foo",
+            );
+            expectProp.to.have.property("skews").that.has.length(1);
+            expectProp.to.have.property("modules").that.has.length(1);
+
+            expectProp = expect(data).to.have.nested.property(
+              "assets.bundle\\.js.packages.foo.3\\.3\\.3.\\.\\./\\.\\./node_modules/different-foo/node_modules/foo",
+            );
+            expectProp.to.have.property("skews").that.has.length(1);
+            expectProp.to.have.property("modules").that.has.length(2);
           });
       });
     });

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -910,12 +910,10 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
 
     it("handles no node_modules with package.json cases", () => {
       mock({
-        src: {
-          baz: {
-            "package.json": JSON.stringify({
-              name: "baz"
-            }, null, 2)
-          }
+        "src/baz": {
+          "package.json": JSON.stringify({
+            name: "baz"
+          }, null, 2)
         }
       });
 
@@ -956,9 +954,11 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
     });
 
     // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
-    // TODO UNSKIP
-    // tslint:disable-next-line max-line-length
-    (process.env.TEMP_ROOTS ? it.only : it.skip)("handles hidden application roots", () => {
+    it("handles hidden application roots", () => {
+      mock({
+        "test/fixtures/hidden-app-roots": fixtureDirs["test/fixtures/hidden-app-roots"],
+      });
+
       const appRoot = resolve("test/fixtures/hidden-app-roots");
       const mods = [
         {
@@ -989,7 +989,7 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
       return _packageRoots(mods).then((pkgRoots) => {
         expect(pkgRoots).to.eql([
           appRoot,
-          `${appRoot}/packages/hidden-app`,
+          join(appRoot, "packages/hidden-app"),
         ]);
       });
     });

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -882,44 +882,78 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
   });
 
   describe("_packageRoots", () => {
-    // TODO: HERE MOCK EVERYTHING!!!!
+    beforeEach(() => {
+      mock({});
+    });
 
-    it("handles base cases", () => _packageRoots([]).then((pkgRoots) => {
-      expect(pkgRoots).to.eql([]);
-    }));
+    it("handles base cases", () => {
+      return _packageRoots([]).then((pkgRoots) => {
+        expect(pkgRoots).to.eql([]);
+      });
+    });
 
-    it("handles no node_modules cases", () => _packageRoots([
+    it("handles no node_modules cases", () => {
+      return _packageRoots([
+        {
+          identifier: resolve("src/baz/index.js"),
+          isNodeModules: false,
+        },
+        {
+          identifier: resolve("src/baz/bug.js"),
+          isNodeModules: false,
+        },
+      ])
+      .then((pkgRoots) => {
+        expect(pkgRoots).to.eql([]);
+      });
+    });
+
+    it("handles no node_modules with package.json cases", () => {
+      mock({
+        src: {
+          baz: {
+            "package.json": JSON.stringify({
+              name: "baz"
+            }, null, 2)
+          }
+        }
+      });
+
+      return _packageRoots([
+        {
+          identifier: resolve("src/baz/index.js"),
+          isNodeModules: false,
+        },
+        {
+          identifier: resolve("src/baz/bug.js"),
+          isNodeModules: false,
+        },
+      ])
+      .then((pkgRoots) => {
+        expect(pkgRoots).to.eql([]);
+      });
+    });
+
+    it("handles simple cases", () => {
+      return _packageRoots([
         {
           identifier: resolve("/my-app/src/baz/index.js"),
           isNodeModules: false,
         },
         {
-          identifier: resolve("/my-app/src/baz/bug.js"),
-          isNodeModules: false,
+          identifier: resolve("/my-app/node_modules/foo/index.js"),
+          isNodeModules: true,
         },
-      ])
-      .then((pkgRoots) => {
-       expect(pkgRoots).to.eql([]);
-    }));
-
-    it("handles simple cases", () => _packageRoots([
-      {
-        identifier: resolve("/my-app/src/baz/index.js"),
-        isNodeModules: false,
-      },
-      {
-        identifier: resolve("/my-app/node_modules/foo/index.js"),
-        isNodeModules: true,
-      },
-      {
-        identifier: resolve("/my-app/node_modules/foo/node_modules/bug/bug.js"),
-        isNodeModules: true,
-      },
-    ]).then((pkgRoots) => {
-      expect(pkgRoots).to.eql([
-        resolve("/my-app"),
-      ]);
-    }));
+        {
+          identifier: resolve("/my-app/node_modules/foo/node_modules/bug/bug.js"),
+          isNodeModules: true,
+        },
+      ]).then((pkgRoots) => {
+        expect(pkgRoots).to.eql([
+          resolve("/my-app"),
+        ]);
+      });
+    });
 
     // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
     // TODO UNSKIP

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -882,6 +882,8 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
   });
 
   describe("_packageRoots", () => {
+    // TODO: HERE MOCK EVERYTHING!!!!
+
     it("handles base cases", () => _packageRoots([]).then((pkgRoots) => {
       expect(pkgRoots).to.eql([]);
     }));

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -599,7 +599,7 @@ describe("lib/actions/versions", () => {
       });
 
       // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
-      it.skip("displays versions skews correctly for hidden app roots", () => { // TODO UNSKIP
+      it.only("displays versions skews correctly for hidden app roots", () => { // TODO UNSKIP
         mock({
           "test/fixtures/hidden-app-roots": fixtureDirs["test/fixtures/hidden-app-roots"],
         });
@@ -619,7 +619,7 @@ describe("lib/actions/versions", () => {
               },
               packageRoots: [
                 resolve(__dirname, "../../fixtures/hidden-app-roots"),
-                //resolve(__dirname, "../../fixtures/hidden-app-roots/packages/hidden-app"),
+                // TODO: resolve(__dirname, "../../fixtures/hidden-app-roots/packages/hidden-app"),
               ],
               packages: {
                 num: 1,
@@ -634,7 +634,7 @@ describe("lib/actions/versions", () => {
       });
 
       // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
-      it.skip("displays versions skews correctly for hidden app roots with empty node_modules", () => { // TODO UNSKIP
+      it.only("displays versions skews correctly for hidden app roots with empty node_modules", () => { // TODO UNSKIP
         const curFixtures = fixtureDirs["test/fixtures/hidden-app-roots"];
         // Add empty `node_modules` to hit different code path.
         curFixtures.packages["hidden-app"].node_modules = {};

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -918,6 +918,40 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
       ]);
     });
 
+    // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
+    // TODO UNSKIP
+    // tslint:disable-next-line max-line-length
+    (process.env.TEMP_ROOTS ? it.only : it.skip)("handles hidden application roots", () => {
+      // TODO: NOT WINDOWS COMPATIBLE
+      const appRoot = resolve("test/fixtures/hidden-app-roots");
+      const mods = [
+        {
+          identifier: `${appRoot}/node_modules/different-foo/index.js`,
+          isNodeModules: true,
+        },
+        {
+          identifier: `${appRoot}/node_modules/different-foo/node_modules/foo/car.js`,
+          isNodeModules: true,
+        },
+        {
+          identifier: `${appRoot}/node_modules/different-foo/node_modules/foo/index.js`,
+          isNodeModules: true,
+        },
+        {
+          identifier: `${appRoot}/node_modules/foo/index.js`,
+          isNodeModules: true,
+        },
+        {
+          identifier: `${appRoot}/packages/hidden-app/src/index.js`,
+          isNodeModules: false,
+        },
+      ];
+
+      expect(_packageRoots(mods)).to.eql([
+        appRoot,
+        `${appRoot}/packages/hidden-app`,
+      ]);
+    });
   });
 
   describe("_packageName", () => {

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -990,6 +990,79 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
         ]);
       });
     });
+
+    // TODO UNSKIP
+    // TODO IMPLEMENT
+    // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
+    it.skip("handles complex hidden application roots", () => {
+      mock({
+        "complex-hidden-app-roots": {}
+      });
+
+      const appRoot = resolve("complex-hidden-app-roots");
+      const mods = [
+        {
+          identifier: "node_modules/prop-types/factoryWithThrowingShims.js",
+          isNodeModules: true,
+        },
+        {
+          identifier: "node_modules/fbjs/lib/shallowEqual.js",
+          isNodeModules: true,
+        },
+        {
+          identifier: "node_modules/react-addons-shallow-compare/node_modules/fbjs/lib/shallowEqual.js",
+          isNodeModules: true,
+        },
+        {
+          identifier: "node_modules/react-apollo/node_modules/prop-types/factoryWithThrowingShims.js",
+          isNodeModules: true,
+        },
+        {
+          identifier: "node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
+          isNodeModules: true,
+        },
+        {
+          identifier: "node_modules/react-apollo/node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js",
+          isNodeModules: true,
+        },
+        {
+          identifier: "node_modules/prop-types/lib/ReactPropTypesSecret.js",
+          isNodeModules: true,
+        },
+        {
+          identifier: "node_modules/react-apollo/node_modules/prop-types/lib/ReactPropTypesSecret.js",
+          isNodeModules: true,
+        },
+        {
+          identifier: "node_modules/css-in-js-utils/lib/hyphenateProperty.js",
+          isNodeModules: true,
+        },
+        {
+          identifier: "node_modules/inline-style-prefixer/node_modules/css-in-js-utils/lib/hyphenateProperty.js",
+          isNodeModules: true,
+        },
+        {
+          identifier: "node_modules/react-apollo/node_modules/prop-types/index.js",
+          isNodeModules: true,
+        },
+        {
+          identifier: "node_modules/prop-types/index.js",
+          isNodeModules: true,
+        },
+        {
+          identifier: "packages/hidden-app/src/index.js",
+          isNodeModules: false,
+        },
+      ].map(({ identifier, isNodeModules }) => ({
+        identifier: join(appRoot, identifier),
+        isNodeModules,
+      }));
+
+      return _packageRoots(mods).then((pkgRoots) => {
+        expect(pkgRoots).to.eql([
+        ]);
+      });
+    });
   });
 
   describe("_packageName", () => {

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -925,30 +925,32 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
     // TODO UNSKIP
     // tslint:disable-next-line max-line-length
     (process.env.TEMP_ROOTS ? it.only : it.skip)("handles hidden application roots", () => {
-      // TODO: NOT WINDOWS COMPATIBLE
       const appRoot = resolve("test/fixtures/hidden-app-roots");
       const mods = [
         {
-          identifier: `${appRoot}/node_modules/different-foo/index.js`,
+          identifier: "node_modules/different-foo/index.js",
           isNodeModules: true,
         },
         {
-          identifier: `${appRoot}/node_modules/different-foo/node_modules/foo/car.js`,
+          identifier: "node_modules/different-foo/node_modules/foo/car.js",
           isNodeModules: true,
         },
         {
-          identifier: `${appRoot}/node_modules/different-foo/node_modules/foo/index.js`,
+          identifier: "node_modules/different-foo/node_modules/foo/index.js",
           isNodeModules: true,
         },
         {
-          identifier: `${appRoot}/node_modules/foo/index.js`,
+          identifier: "node_modules/foo/index.js",
           isNodeModules: true,
         },
         {
-          identifier: `${appRoot}/packages/hidden-app/src/index.js`,
+          identifier: "packages/hidden-app/src/index.js",
           isNodeModules: false,
         },
-      ];
+      ].map(({ identifier, isNodeModules }) => ({
+        identifier: join(appRoot, identifier),
+        isNodeModules,
+      }));
 
       return _packageRoots(mods).then((pkgRoots) => {
         expect(pkgRoots).to.eql([

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -599,7 +599,9 @@ describe("lib/actions/versions", () => {
       });
 
       // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
-      (process.env.TEMP_ROOTS ? it.only : it.skip)("displays versions skews correctly for hidden app roots", () => { // TODO UNSKIP
+      // TODO UNSKIP
+      // tslint:disable-next-line max-line-length
+      (process.env.TEMP_ROOTS ? it.only : it.skip)("displays versions skews correctly for hidden app roots", () => {
         mock({
           "test/fixtures/hidden-app-roots": fixtureDirs["test/fixtures/hidden-app-roots"],
         });
@@ -646,7 +648,9 @@ describe("lib/actions/versions", () => {
       });
 
       // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
-      (process.env.TEMP_ROOTS ? it.only : it.skip)("displays versions skews correctly for hidden app roots with empty node_modules", () => { // TODO UNSKIP
+      // TODO UNSKIP
+      // tslint:disable-next-line max-line-length
+      (process.env.TEMP_ROOTS ? it.only : it.skip)("displays versions skews correctly for hidden app roots with empty node_modules", () => {
         const curFixtures = fixtureDirs["test/fixtures/hidden-app-roots"];
         // Add empty `node_modules` to hit different code path.
         curFixtures.packages["hidden-app"].node_modules = {};

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -599,7 +599,7 @@ describe("lib/actions/versions", () => {
       });
 
       // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
-      it.only("displays versions skews correctly for hidden app roots", () => { // TODO UNSKIP
+      it.skip("displays versions skews correctly for hidden app roots", () => { // TODO UNSKIP
         mock({
           "test/fixtures/hidden-app-roots": fixtureDirs["test/fixtures/hidden-app-roots"],
         });
@@ -634,7 +634,7 @@ describe("lib/actions/versions", () => {
       });
 
       // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
-      it.only("displays versions skews correctly for hidden app roots with empty node_modules", () => { // TODO UNSKIP
+      it.skip("displays versions skews correctly for hidden app roots with empty node_modules", () => { // TODO UNSKIP
         const curFixtures = fixtureDirs["test/fixtures/hidden-app-roots"];
         // Add empty `node_modules` to hit different code path.
         curFixtures.packages["hidden-app"].node_modules = {};

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -600,9 +600,7 @@ describe("lib/actions/versions", () => {
       });
 
       // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
-      // TODO UNSKIP
-      // tslint:disable-next-line max-line-length
-      (process.env.TEMP_ROOTS ? it.only : it.skip)("displays versions skews correctly for hidden app roots", () => {
+      it("displays versions skews correctly for hidden app roots", () => {
         mock({
           "test/fixtures/hidden-app-roots": fixtureDirs["test/fixtures/hidden-app-roots"],
         });
@@ -649,11 +647,10 @@ describe("lib/actions/versions", () => {
       });
 
       // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
-      // TODO UNSKIP
-      // tslint:disable-next-line max-line-length
-      (process.env.TEMP_ROOTS ? it.only : it.skip)("displays versions skews correctly for hidden app roots with empty node_modules", () => {
+      it("displays versions skews correctly for hidden app roots with empty node_modules", () => {
         const curFixtures = fixtureDirs["test/fixtures/hidden-app-roots"];
         // Add empty `node_modules` to hit different code path.
+        // TODO: Check this doesn't pollute state.
         curFixtures.packages["hidden-app"].node_modules = {};
 
         mock({
@@ -912,9 +909,9 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
       mock({
         "src/baz": {
           "package.json": JSON.stringify({
-            name: "baz"
-          }, null, 2)
-        }
+            name: "baz",
+          }, null, 2),
+        },
       });
 
       return _packageRoots([

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -599,15 +599,15 @@ describe("lib/actions/versions", () => {
       });
 
       // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
-      it.skip("displays versions skews correctly for hidden app roots", () => { // TODO UNSKIP
+      it.only("displays versions skews correctly for hidden app roots", () => { // TODO UNSKIP
         mock({
           "test/fixtures/hidden-app-roots": fixtureDirs["test/fixtures/hidden-app-roots"],
         });
 
-        return scopedInstance.getData()
+        return hiddenAppRootsInstance.getData()
           .then((data) => {
             expect(data).to.have.keys("meta", "assets");
-            expect(data).to.have.property("meta").that.eql(merge(BASE_SCOPED_DATA.meta, {
+            expect(data).to.have.property("meta").that.eql(merge(EMPTY_VERSIONS_DATA.meta, {
               depended: {
                 num: 2,
               },
@@ -617,6 +617,10 @@ describe("lib/actions/versions", () => {
               installed: {
                 num: 2,
               },
+              packageRoots: [
+                resolve(__dirname, "../../fixtures/hidden-app-roots"),
+                resolve(__dirname, "../../fixtures/hidden-app-roots/packages/hidden-app"),
+              ],
               packages: {
                 num: 1,
               },

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -599,7 +599,7 @@ describe("lib/actions/versions", () => {
       });
 
       // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
-      it.only("displays versions skews correctly for hidden app roots", () => { // TODO UNSKIP
+      it.skip("displays versions skews correctly for hidden app roots", () => { // TODO UNSKIP
         mock({
           "test/fixtures/hidden-app-roots": fixtureDirs["test/fixtures/hidden-app-roots"],
         });
@@ -619,7 +619,7 @@ describe("lib/actions/versions", () => {
               },
               packageRoots: [
                 resolve(__dirname, "../../fixtures/hidden-app-roots"),
-                resolve(__dirname, "../../fixtures/hidden-app-roots/packages/hidden-app"),
+                //resolve(__dirname, "../../fixtures/hidden-app-roots/packages/hidden-app"),
               ],
               packages: {
                 num: 1,

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -90,6 +90,7 @@ describe("lib/actions/versions", () => {
   let dupsCjsInstance;
   let scopedInstance;
   let multipleRootsInstance;
+  let hiddenAppRootsInstance;
 
   const getData = (name) => Promise.resolve()
     .then(() => create({ stats: fixtures[toPosixPath(name)] }).validate())
@@ -106,6 +107,7 @@ describe("lib/actions/versions", () => {
     "duplicates-cjs",
     "scoped",
     "multiple-roots",
+    "hidden-app-roots",
   ].map((name) => create({
       stats: fixtures[toPosixPath(join(name, "dist-development-4"))],
     }).validate()))
@@ -115,12 +117,14 @@ describe("lib/actions/versions", () => {
         dupsCjsInstance,
         scopedInstance,
         multipleRootsInstance,
+        hiddenAppRootsInstance,
       ] = instances;
 
       expect(simpleInstance).to.not.be.an("undefined");
       expect(dupsCjsInstance).to.not.be.an("undefined");
       expect(scopedInstance).to.not.be.an("undefined");
       expect(multipleRootsInstance).to.not.be.an("undefined");
+      expect(hiddenAppRootsInstance).to.not.be.an("undefined");
     }),
   );
 
@@ -593,6 +597,37 @@ describe("lib/actions/versions", () => {
             expectProp.to.have.property("modules").that.has.length(2);
           });
       });
+
+      // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
+      it.skip("displays versions skews correctly for hidden app roots", () => { // TODO UNSKIP
+        mock({
+          "test/fixtures/hidden-app-roots": fixtureDirs["test/fixtures/hidden-app-roots"],
+        });
+
+        return scopedInstance.getData()
+          .then((data) => {
+            expect(data).to.have.keys("meta", "assets");
+            expect(data).to.have.property("meta").that.eql(merge(BASE_SCOPED_DATA.meta, {
+              depended: {
+                num: 2,
+              },
+              files: {
+                num: 2,
+              },
+              installed: {
+                num: 2,
+              },
+              packages: {
+                num: 1,
+              },
+              resolved: {
+                num: 2,
+              },
+            }));
+
+            console.log("TODO HERE -- ASSERTS"); // tslint:disable-line no-console
+          });
+      });
     });
   });
 
@@ -744,6 +779,9 @@ inspectpack --action=versions
           `.trim());
         });
     });
+
+    // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
+    it("displays versions skews correctly for hidden app roots"); // TODO IMPLEMENT
   });
 
   describe("tsv", () => {
@@ -766,6 +804,9 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
           /*tslint:enable max-line-length*/
         });
     });
+
+    // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
+    it("displays versions skews correctly for hidden app roots"); // TODO IMPLEMENT
   });
 
   describe("_packageName", () => {

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -930,22 +930,30 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
     });
 
     it("handles simple cases", () => {
+      mock({
+        "my-app": {
+          "package.json": JSON.stringify({
+            name: "my-app",
+          }, null, 2),
+        },
+      });
+
       return _packageRoots([
         {
-          identifier: resolve("/my-app/src/baz/index.js"),
+          identifier: resolve("my-app/src/baz/index.js"),
           isNodeModules: false,
         },
         {
-          identifier: resolve("/my-app/node_modules/foo/index.js"),
+          identifier: resolve("my-app/node_modules/foo/index.js"),
           isNodeModules: true,
         },
         {
-          identifier: resolve("/my-app/node_modules/foo/node_modules/bug/bug.js"),
+          identifier: resolve("my-app/node_modules/foo/node_modules/bug/bug.js"),
           isNodeModules: true,
         },
       ]).then((pkgRoots) => {
         expect(pkgRoots).to.eql([
-          resolve("/my-app"),
+          resolve("my-app"),
         ]);
       });
     });
@@ -996,10 +1004,11 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
     // Regression test: https://github.com/FormidableLabs/inspectpack/issues/103
     it.skip("handles complex hidden application roots", () => {
       mock({
-        "complex-hidden-app-roots": {}
+        "complex-hidden-app-roots": {},
       });
 
       const appRoot = resolve("complex-hidden-app-roots");
+      // tslint:disable max-line-length
       const mods = [
         {
           identifier: "node_modules/prop-types/factoryWithThrowingShims.js",
@@ -1057,6 +1066,7 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
         identifier: join(appRoot, identifier),
         isNodeModules,
       }));
+      // tslint:enable max-line-length
 
       return _packageRoots(mods).then((pkgRoots) => {
         expect(pkgRoots).to.eql([

--- a/test/lib/util/dependencies.spec.ts
+++ b/test/lib/util/dependencies.spec.ts
@@ -320,7 +320,7 @@ describe("lib/util/dependencies", () => {
       };
       const foo = {
         name: "foo",
-        version: "1.0.0",
+        version: "3.0.0",
       };
 
       expect(_findPackage({ ..._baseArgs, pkgMap: {
@@ -333,7 +333,29 @@ describe("lib/util/dependencies", () => {
       });
     });
 
-    it("finds hidden roots packages outside of file path"); // TODO IMPLEMENT
+    // TODO: UNSKIP FAILING TEST
+    it.skip("finds hidden roots packages outside of file path", () => {
+      const myPkg = {
+        dependencies: {
+          foo: "^3.0.0",
+        },
+        name: "my-pkg",
+        version: "1.0.2",
+      };
+      const foo = {
+        name: "foo",
+        version: "3.0.0",
+      };
+
+      expect(_findPackage({ ..._baseArgs, pkgMap: {
+        "base/node_modules/foo/package.json": foo,
+        "base/packages/my-pkg/package.json": myPkg,
+      } })).to.eql({
+        isFlattened: true, // TODO: THIS IS FAILING.
+        pkgObj: foo,
+        pkgPath: "base/node_modules/foo",
+      });
+    });
   });
 
   describe("dependencies", () => {

--- a/test/lib/util/dependencies.spec.ts
+++ b/test/lib/util/dependencies.spec.ts
@@ -332,6 +332,8 @@ describe("lib/util/dependencies", () => {
         pkgPath: "base/node_modules/foo",
       });
     });
+
+    it("finds hidden roots packages outside of file path"); // TODO IMPLEMENT
   });
 
   describe("dependencies", () => {

--- a/test/lib/util/dependencies.spec.ts
+++ b/test/lib/util/dependencies.spec.ts
@@ -228,6 +228,61 @@ describe("lib/util/dependencies", () => {
           });
         });
     });
+
+    it("includes multiple deps", () => {
+      const foo1 = {
+        name: "foo",
+        version: "1.0.0",
+      };
+      const diffFoo = {
+        dependencies: {
+          foo: "^3.0.0",
+        },
+        name: "different-foo",
+        version: "1.0.1",
+      };
+      const foo3 = {
+        name: "foo",
+        version: "3.0.0",
+      };
+      const root = {
+        dependencies: {
+          "different-foo": "1.0.0",
+          "foo": "^3.0.0",
+        },
+        name: "root",
+        version: "1.0.2",
+      };
+
+      mock({
+        "node_modules": {
+          "different-foo": {
+            "node_modules": {
+              foo: {
+                "package.json": JSON.stringify(foo3),
+              },
+            },
+            "package.json": JSON.stringify(diffFoo),
+          },
+          "foo": {
+            "package.json": JSON.stringify(foo1),
+          },
+        },
+        "package.json": JSON.stringify(root),
+      });
+
+      return readPackages(".")
+        .then(_resolvePackageMap)
+        .then(posixifyKeys)
+        .then((pkgs) => {
+          expect(pkgs).to.eql({
+            "node_modules/different-foo/node_modules/foo/package.json": foo3,
+            "node_modules/different-foo/package.json": diffFoo,
+            "node_modules/foo/package.json": foo1,
+            "package.json": root,
+          });
+        });
+    });
   });
 
   describe("dependencies", () => {

--- a/test/lib/util/promise.spec.ts
+++ b/test/lib/util/promise.spec.ts
@@ -1,0 +1,28 @@
+import {
+  serial,
+} from "../../../src/lib/util/promise";
+
+describe("lib/util/promise", () => {
+
+  describe("serial", () => {
+    it("handles base cases", () =>
+      serial([])
+        .then((vals) => {
+          expect(vals).to.eql([]);
+        }),
+    );
+
+    it("handles arrays", () =>
+      serial([
+        () => Promise.resolve(10),
+        () => Promise.resolve(20),
+      ])
+        .then((vals) => {
+          expect(vals).to.eql([
+            10,
+            20,
+          ]);
+        }),
+    );
+  });
+});

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -37,6 +37,9 @@ const FIXTURES_STATS = FIXTURES_DIRS.map((f) => join(__dirname, "fixtures", f, "
 // Extra patches for webpack-config-driven stuff that doesn't fit within
 // node_modules-based traversals.
 const FIXTURES_EXTRA_DIRS = {
+  "hidden-app-roots": [
+    "packages/hidden-app",
+  ],
   "multiple-roots": [
     "packages/package1",
     "packages/package2",


### PR DESCRIPTION
When an application root has no actual `node_modules` in it, the `versions` action inference fails to find the app root `package.json` file and misses traversing the versions dependencies. This has the buggy effects of:

- Missing information in `versions` action for CLI
- Missing information in `DuplicatesPlugin`.

## Work

- [x] Create regression test fixtures
- [x] Create regression tests
- [ ] Create fix. Fixes #103 

## Example

The regression fixture displays similar bad output to the original bug #103 :

```
[Building fixture] ../../test/fixtures/hidden-app-roots/dist-production-4/bundle.js

Hash: ad1c54643fd96dfbb316
Version: webpack 4.6.0
Time: 169ms
Built at: 2019-02-26 11:16:37
     Asset       Size  Chunks             Chunk Names
 bundle.js  874 bytes       0  [emitted]  bundle
stats.json   8.38 KiB          [emitted]  
Entrypoint bundle = bundle.js
[4] ./packages/hidden-app/src/index.js 245 bytes {0} [built]
    + 4 hidden modules

WARNING in Duplicate Sources / Packages - Duplicates found! ⚠️

* Duplicates: Found 2 similar files across 2 code sources (both identical + similar)
  accounting for 118 bundled bytes.
* Packages: Found 0 packages with 0 resolved, 0 installed, and 0 depended versions.

* Understanding the report: Need help with the details? See:
  https://github.com/FormidableLabs/inspectpack/#diagnosing-duplicates
* Fixing bundle duplicates: An introductory guide:
  https://github.com/FormidableLabs/inspectpack/#fixing-bundle-duplicates
```