### PR TITLE
BUG: Handle null chunks in webpack stats object.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,11 @@
 History
 =======
 
+## Unreleased
+
+* BUG: Handle `null` chunks in webpack stats object.
+  [#110](https://github.com/FormidableLabs/inspectpack/issues/110)
+
 ## 4.2.0
 
 * Add `commonRoot` to `versions` metadata to indicate what installed paths are relative to.

--- a/src/lib/actions/base.ts
+++ b/src/lib/actions/base.ts
@@ -262,6 +262,9 @@ export abstract class Action {
       };
 
       asset.chunks.forEach((chunk) => {
+        // Skip null chunks, allowing only strings or numbers.
+        if (chunk === null) { return; }
+
         chunk = chunk.toString(); // force to string.
         chunksToAssets[chunk] = chunksToAssets[chunk] || new Set();
 
@@ -273,6 +276,9 @@ export abstract class Action {
     // Iterate modules and attach as appropriate.
     this.modules.forEach((mod) => {
       mod.chunks.forEach((chunk) => {
+        // Skip null chunks, allowing only strings or numbers.
+        if (chunk === null) { return; }
+
         chunk = chunk.toString(); // force to string.
         (chunksToAssets[chunk] || []).forEach((assetName) => {
           const assetObj = modulesSetByAsset[assetName];

--- a/src/lib/interfaces/webpack-stats.ts
+++ b/src/lib/interfaces/webpack-stats.ts
@@ -17,7 +17,7 @@ import * as t from "io-ts";
  */
 
 // Common
-const RWebpackStatsChunk = t.union([t.string, t.number]);
+const RWebpackStatsChunk = t.union([t.string, t.number, t.null]);
 
 export type IWebpackStatsChunk = t.TypeOf<typeof RWebpackStatsChunk>;
 

--- a/test/lib/actions/sizes.spec.ts
+++ b/test/lib/actions/sizes.spec.ts
@@ -271,126 +271,154 @@ describe("lib/actions/sizes", () => {
   });
 
   describe("json", () => {
+    /*tslint:disable max-line-length*/
+    const expectedScopedData = {
+      assets: {
+        "bundle.js": {
+          files: [
+            {
+              baseName: "@scope/foo/bike.js",
+              fileName: "scoped/node_modules/@scope/foo/bike.js",
+              size: {
+                full: "NUM",
+              },
+            },
+            {
+              baseName: "@scope/foo/index.js",
+              fileName: "scoped/node_modules/@scope/foo/index.js",
+              size: {
+                full: "NUM",
+              },
+            },
+            {
+              baseName: "bar/index.js",
+              fileName: "scoped/node_modules/bar/index.js",
+              size: {
+                full: "NUM",
+              },
+            },
+            {
+              baseName: "bar/tender.js",
+              fileName: "scoped/node_modules/bar/tender.js",
+              size: {
+                full: "NUM",
+              },
+            },
+            {
+              baseName: "flattened-foo/index.js",
+              fileName: "scoped/node_modules/flattened-foo/index.js",
+              size: {
+                full: "NUM",
+              },
+            },
+            {
+              baseName: "unscoped-foo/index.js",
+              fileName: "scoped/node_modules/unscoped-foo/index.js",
+              size: {
+                full: "NUM",
+              },
+            },
+            {
+              baseName: "deeper-unscoped/index.js",
+              fileName: "scoped/node_modules/unscoped-foo/node_modules/deeper-unscoped/index.js",
+              size: {
+                full: "NUM",
+              },
+            },
+            {
+              baseName: "foo/car.js",
+              fileName: "scoped/node_modules/unscoped-foo/node_modules/deeper-unscoped/node_modules/foo/car.js",
+              size: {
+                full: "NUM",
+              },
+            },
+            {
+              baseName: "foo/index.js",
+              fileName: "scoped/node_modules/unscoped-foo/node_modules/deeper-unscoped/node_modules/foo/index.js",
+              size: {
+                full: "NUM",
+              },
+            },
+            {
+              baseName: "foo/car.js",
+              fileName: "scoped/node_modules/unscoped-foo/node_modules/foo/car.js",
+              size: {
+                full: "NUM",
+              },
+            },
+            {
+              baseName: "foo/index.js",
+              fileName: "scoped/node_modules/unscoped-foo/node_modules/foo/index.js",
+              size: {
+                full: "NUM",
+              },
+            },
+            {
+              baseName: "uses-foo/index.js",
+              fileName: "scoped/node_modules/uses-foo/index.js",
+              size: {
+                full: "NUM",
+              },
+            },
+            {
+              baseName: "@scope/foo/index.js",
+              fileName: "scoped/node_modules/uses-foo/node_modules/@scope/foo/index.js",
+              size: {
+                full: "NUM",
+              },
+            },
+            {
+              baseName: null,
+              fileName: "scoped/src/index.js",
+              size: {
+                full: "NUM",
+              },
+            },
+          ],
+          meta: {
+            full: "NUM",
+          },
+        },
+      },
+      meta: {
+        full: "NUM",
+      },
+    };
+    /*tslint:enable max-line-length*/
+
     it("displays sizes correctly for scoped packages", () => {
       return scopedInstance.template.json()
         .then((dataStr) => {
           // Inflate to real object and re-use previous test assertions.
           const data = JSON.parse(normalizeOutput(JSON_PATH_RE, dataStr));
 
-          /*tslint:disable max-line-length*/
-          expect(data).to.eql({
-            assets: {
-              "bundle.js": {
-                files: [
-                  {
-                    baseName: "@scope/foo/bike.js",
-                    fileName: "scoped/node_modules/@scope/foo/bike.js",
-                    size: {
-                      full: "NUM",
-                    },
-                  },
-                  {
-                    baseName: "@scope/foo/index.js",
-                    fileName: "scoped/node_modules/@scope/foo/index.js",
-                    size: {
-                      full: "NUM",
-                    },
-                  },
-                  {
-                    baseName: "bar/index.js",
-                    fileName: "scoped/node_modules/bar/index.js",
-                    size: {
-                      full: "NUM",
-                    },
-                  },
-                  {
-                    baseName: "bar/tender.js",
-                    fileName: "scoped/node_modules/bar/tender.js",
-                    size: {
-                      full: "NUM",
-                    },
-                  },
-                  {
-                    baseName: "flattened-foo/index.js",
-                    fileName: "scoped/node_modules/flattened-foo/index.js",
-                    size: {
-                      full: "NUM",
-                    },
-                  },
-                  {
-                    baseName: "unscoped-foo/index.js",
-                    fileName: "scoped/node_modules/unscoped-foo/index.js",
-                    size: {
-                      full: "NUM",
-                    },
-                  },
-                  {
-                    baseName: "deeper-unscoped/index.js",
-                    fileName: "scoped/node_modules/unscoped-foo/node_modules/deeper-unscoped/index.js",
-                    size: {
-                      full: "NUM",
-                    },
-                  },
-                  {
-                    baseName: "foo/car.js",
-                    fileName: "scoped/node_modules/unscoped-foo/node_modules/deeper-unscoped/node_modules/foo/car.js",
-                    size: {
-                      full: "NUM",
-                    },
-                  },
-                  {
-                    baseName: "foo/index.js",
-                    fileName: "scoped/node_modules/unscoped-foo/node_modules/deeper-unscoped/node_modules/foo/index.js",
-                    size: {
-                      full: "NUM",
-                    },
-                  },
-                  {
-                    baseName: "foo/car.js",
-                    fileName: "scoped/node_modules/unscoped-foo/node_modules/foo/car.js",
-                    size: {
-                      full: "NUM",
-                    },
-                  },
-                  {
-                    baseName: "foo/index.js",
-                    fileName: "scoped/node_modules/unscoped-foo/node_modules/foo/index.js",
-                    size: {
-                      full: "NUM",
-                    },
-                  },
-                  {
-                    baseName: "uses-foo/index.js",
-                    fileName: "scoped/node_modules/uses-foo/index.js",
-                    size: {
-                      full: "NUM",
-                    },
-                  },
-                  {
-                    baseName: "@scope/foo/index.js",
-                    fileName: "scoped/node_modules/uses-foo/node_modules/@scope/foo/index.js",
-                    size: {
-                      full: "NUM",
-                    },
-                  },
-                  {
-                    baseName: null,
-                    fileName: "scoped/src/index.js",
-                    size: {
-                      full: "NUM",
-                    },
-                  },
-                ],
-                meta: {
-                  full: "NUM",
-                },
-              },
-            },
-            meta: {
-              full: "NUM",
-            },
-          });
-          /*tslint:enable max-line-length*/
+          expect(data).to.eql(expectedScopedData);
+        });
+    });
+
+    // Regression test:
+    // https://github.com/FormidableLabs/inspectpack/issues/110
+    it("displays sizes correctly for scoped packages with null chunks", () => {
+      // Mutate stats data to replicate null chunk scenario.
+
+      // Add null asset chunk.
+      scopedInstance.stats.assets[0].chunks = [null].concat(
+        scopedInstance.stats.assets[0].chunks,
+      );
+
+      // Add null module chunks.
+      scopedInstance.stats.modules.forEach((mod) => {
+        if (mod.chunks) {
+          mod.chunks = [null, null, null].concat(mod.chunks);
+        }
+      });
+
+      return scopedInstance.template.json()
+        .then((dataStr) => {
+          // Inflate to real object and re-use previous test assertions.
+          const data = JSON.parse(normalizeOutput(JSON_PATH_RE, dataStr));
+
+          expect(data).to.eql(expectedScopedData);
         });
     });
   });


### PR DESCRIPTION
- Expand type to allow `null` and handle in code. Fixes #110 
- Add regression tests.

@westbrook-asapp - If you have a moment, want to try this one out? (No worries if not, I'm pretty sure this fixes the issue as your stats file now is parseable with this change. Thanks again so much for generating it -- it dramatically reduced the amount of time needed to fix this!)

/cc @parkerziegler 