### PR TITLE
Feature: Add ignored packages option to plugin + CLI

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,11 @@
 History
 =======
 
+## UNRELEASED
+
+* Add `ignoredPackages` plugin option (string or regex) and `--ignored-packages|-i` CLI option (string) to ignore packages in respective outputs.
+  [#118](https://github.com/FormidableLabs/inspectpack/issues/118) (*[@tido64][]*)
+
 ## 4.3.1
 
 * BUG: Handle circular dependencies recursion issue in `versions`.
@@ -242,4 +247,5 @@ History
 [@rgerstenberger]: https://github.com/rgerstenberger
 [@ryan-codingintrigue]: https://github.com/ryan-codingintrigue
 [@ryan-roemer]: https://github.com/ryan-roemer
+[@tido64]: https://github.com/tido64
 [@tptee]: https://github.com/tptee

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ module.exports = {
       // Handle all messages with handler function (`(report: string)`)
       // Overrides `emitErrors` output.
       emitHandler: undefined,
+      // List of packages that can be ignored. (Default: `[]`)
+      ignoredPackages: undefined,
       // Display full duplicates information? (Default: `false`)
       verbose: false
     })
@@ -488,7 +490,7 @@ Other tools that inspect Webpack bundles:
 
 ## Maintenance Status
 
-**Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome. 
+**Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome.
 
 [npm_img]: https://badge.fury.io/js/inspectpack.svg
 [npm_site]: http://badge.fury.io/js/inspectpack

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ module.exports = {
       // Overrides `emitErrors` output.
       emitHandler: undefined,
       // List of packages that can be ignored. (Default: `[]`)
+      // - If a string, then a prefix match of `{$name}/` for each module.
+      // - If a regex, then `.test(pattern)` which means you should add slashes
+      //   where appropriate.
+      //
+      // **Note**: Uses posix paths for all matching (e.g., on windows `/` not `\`).
       ignoredPackages: undefined,
       // Display full duplicates information? (Default: `false`)
       verbose: false
@@ -280,13 +285,16 @@ From there, you can run the `inspectpack` command line tool from anywhere!
 Usage: inspectpack -s <file> -a <action> [options]
 
 Options:
-  --action, -a   Actions to take
+  --action, -a            Actions to take
                 [string] [required] [choices: "duplicates", "sizes", "versions"]
-  --stats, -s    Path to webpack-created stats JSON object   [string] [required]
-  --format, -f   Display output format
+  --stats, -s             Path to webpack-created stats JSON object
+                                                             [string] [required]
+  --format, -f            Display output format
                      [string] [choices: "json", "text", "tsv"] [default: "text"]
-  --help, -h     Show help                                             [boolean]
-  --version, -v  Show version number                                   [boolean]
+  --ignored-packages, -i  List of package names (space separated) to ignore
+                                                           [array] [default: []]
+  --help, -h              Show help                                    [boolean]
+  --version, -v           Show version number                          [boolean]
 
 Examples:
   inspectpack -s stats.json -a duplicates  Show duplicates files

--- a/src/bin/lib/args.ts
+++ b/src/bin/lib/args.ts
@@ -7,12 +7,10 @@ import {
   TemplateFormat,
 } from "../../lib";
 
-const ACTION_KEYS = Object.keys(ACTIONS);
-
 // Validate and normalize.
 const validate = (parser: yargs.Argv): Promise<IRenderOptions> => {
   const { argv } = parser;
-  const { action, format } = argv;
+  const { action, format, ignoredPackages } = argv;
 
   // Defaults
   const statsFile = argv.stats as string;
@@ -20,6 +18,7 @@ const validate = (parser: yargs.Argv): Promise<IRenderOptions> => {
   return readJson(statsFile).then((stats) => ({
     action,
     format,
+    ignoredPackages,
     stats,
   }) as IRenderOptions);
 };
@@ -30,7 +29,7 @@ const args = () => yargs
   // Actions
   .option("action", {
     alias: "a",
-    choices: ACTION_KEYS,
+    choices: Object.keys(ACTIONS),
     describe: "Actions to take",
     required: true,
     type: "string",
@@ -63,6 +62,14 @@ const args = () => yargs
     default: TemplateFormat.text,
     describe: "Display output format",
     type: "string",
+  })
+
+  // Ignores
+  .option("ignored-packages", {
+    alias: "i",
+    default: [],
+    describe: "List of space separated packages to ignore",
+    type: "array",
   })
 
   // Logistical

--- a/src/bin/lib/args.ts
+++ b/src/bin/lib/args.ts
@@ -68,7 +68,7 @@ const args = () => yargs
   .option("ignored-packages", {
     alias: "i",
     default: [],
-    describe: "List of space separated packages to ignore",
+    describe: "List of package names (space separated) to ignore",
     type: "array",
   })
 

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -19,7 +19,7 @@ export interface IRenderOptions extends IActionConstructor {
   action: "duplicates" | "sizes" | "versions";
   format: TemplateFormat;
   stats: IWebpackStats;
-  ignoredPackages: string[];
+  ignoredPackages: Array<string | RegExp>;
 }
 
 /**

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -19,6 +19,7 @@ export interface IRenderOptions extends IActionConstructor {
   action: "duplicates" | "sizes" | "versions";
   format: TemplateFormat;
   stats: IWebpackStats;
+  ignoredPackages: string[];
 }
 
 /**
@@ -54,7 +55,7 @@ export const actions = (
  * @returns {Promise<string>} Rendered result
  */
 export const render = (
-  { action, format, stats }: IRenderOptions,
+  { action, format, stats, ignoredPackages }: IRenderOptions,
 ): Promise<string> => Promise.resolve()
-  .then(() => actions(action, { stats }))
+  .then(() => actions(action, { stats, ignoredPackages }))
   .then((instance: IAction) => instance.template.render(format));

--- a/src/lib/actions/base.ts
+++ b/src/lib/actions/base.ts
@@ -179,9 +179,10 @@ export abstract class Action {
   }
 
   protected ignorePackage(baseName: string): boolean {
+    const base = toPosixPath(baseName.trim());
     return this._ignoredPackages.some((pattern) => typeof pattern === "string" ?
-      baseName.startsWith(pattern) :
-      (pattern as RegExp).test(baseName),
+      base.startsWith(pattern) :
+      (pattern as RegExp).test(base),
     );
   }
 

--- a/src/plugin/duplicates.ts
+++ b/src/plugin/duplicates.ts
@@ -40,7 +40,7 @@ interface IDuplicatesPluginConstructor {
   verbose?: boolean;
   emitErrors?: boolean;
   emitHandler?: (report: string) => {};
-  ignoredPackages?: string[];
+  ignoredPackages?: Array<string | RegExp>;
 }
 
 interface IPackageNames {

--- a/src/plugin/duplicates.ts
+++ b/src/plugin/duplicates.ts
@@ -40,6 +40,7 @@ interface IDuplicatesPluginConstructor {
   verbose?: boolean;
   emitErrors?: boolean;
   emitHandler?: (report: string) => {};
+  ignoredPackages?: string[];
 }
 
 interface IPackageNames {
@@ -208,13 +209,13 @@ export const _getDuplicatesVersionsData = (
 export class DuplicatesPlugin {
   private opts: IDuplicatesPluginConstructor;
 
-  constructor(opts: IDuplicatesPluginConstructor | null) {
-    opts = opts || {};
-
-    this.opts = {};
-    this.opts.verbose = opts.verbose === true; // default `false`
-    this.opts.emitErrors = opts.emitErrors === true; // default `false`
-    this.opts.emitHandler = typeof opts.emitHandler === "function" ? opts.emitHandler : undefined;
+  constructor({verbose, emitErrors, emitHandler, ignoredPackages}: IDuplicatesPluginConstructor = {}) {
+    this.opts = {
+      emitErrors: emitErrors === true, // default `false`
+      emitHandler: typeof emitHandler === "function" ? emitHandler : undefined,
+      ignoredPackages: Array.isArray(ignoredPackages) ? ignoredPackages : undefined,
+      verbose: verbose === true, // default `false`
+    };
   }
 
   public apply(compiler: ICompiler) {
@@ -231,7 +232,7 @@ export class DuplicatesPlugin {
     const { errors, warnings } = compilation;
     const stats = compilation.getStats().toJson();
 
-    const { emitErrors, emitHandler, verbose } = this.opts;
+    const { emitErrors, emitHandler, ignoredPackages, verbose } = this.opts;
 
     // Stash messages for output to console (success) or compilation warnings
     // or errors arrays on duplicates found.
@@ -239,7 +240,7 @@ export class DuplicatesPlugin {
     const addMsg = (msg: string) => msgs.push(msg);
 
     return Promise.all([
-      actions("duplicates", { stats }).then((a) => a.getData() as Promise<IDuplicatesData>),
+      actions("duplicates", { stats, ignoredPackages }).then((a) => a.getData() as Promise<IDuplicatesData>),
       actions("versions", { stats }).then((a) => a.getData() as Promise<IVersionsData>),
     ])
       .then((datas) => {

--- a/src/plugin/duplicates.ts
+++ b/src/plugin/duplicates.ts
@@ -241,7 +241,7 @@ export class DuplicatesPlugin {
 
     return Promise.all([
       actions("duplicates", { stats, ignoredPackages }).then((a) => a.getData() as Promise<IDuplicatesData>),
-      actions("versions", { stats }).then((a) => a.getData() as Promise<IVersionsData>),
+      actions("versions", { stats, ignoredPackages }).then((a) => a.getData() as Promise<IVersionsData>),
     ])
       .then((datas) => {
         const [dupData, pkgDataOrig] = datas;

--- a/test/fixtures/config/webpack.config.js
+++ b/test/fixtures/config/webpack.config.js
@@ -76,6 +76,10 @@ const webpack4 = {
     DuplicatesPlugin ? new DuplicatesPlugin({
       verbose: true,
       emitErrors: false
+      // TODO: REMOVE
+      // ignoredPackages: [
+      //   "@scope/foo"
+      // ]
     }) : null
   ].filter(Boolean)
 };

--- a/test/fixtures/config/webpack.config.js
+++ b/test/fixtures/config/webpack.config.js
@@ -76,10 +76,6 @@ const webpack4 = {
     DuplicatesPlugin ? new DuplicatesPlugin({
       verbose: true,
       emitErrors: false
-      // TODO: REMOVE
-      // ignoredPackages: [
-      //   "@scope/foo"
-      // ]
     }) : null
   ].filter(Boolean)
 };

--- a/test/lib/plugin/duplicates.spec.ts
+++ b/test/lib/plugin/duplicates.spec.ts
@@ -302,8 +302,19 @@ foo (Found 1 resolved, 2 installed, 2 depended. Latest 1.1.1.)
               expect(actualReport).to.eql(verboseReport);
             });
           });
-        });
 
+          it(`ignores specified packages`, () => {
+            const plugin = new DuplicatesPlugin({
+              emitErrors: true,
+              ignoredPackages: ["foo"],
+            });
+
+            return plugin.analyze(compilation).then(() => {
+              expect(compilation.warnings).to.eql([]);
+              expect(compilation.errors).to.eql([]);
+            });
+          });
+        });
       });
     });
   });

--- a/test/lib/plugin/duplicates.spec.ts
+++ b/test/lib/plugin/duplicates.spec.ts
@@ -303,10 +303,22 @@ foo (Found 1 resolved, 2 installed, 2 depended. Latest 1.1.1.)
             });
           });
 
-          it(`ignores specified packages`, () => {
+          it(`ignores specified packages with strings`, () => {
             const plugin = new DuplicatesPlugin({
               emitErrors: true,
               ignoredPackages: ["foo"],
+            });
+
+            return plugin.analyze(compilation).then(() => {
+              expect(compilation.warnings).to.eql([]);
+              expect(compilation.errors).to.eql([]);
+            });
+          });
+
+          it(`ignores specified packages with regexes`, () => {
+            const plugin = new DuplicatesPlugin({
+              emitErrors: true,
+              ignoredPackages: [/^f[o]{2}\//],
             });
 
             return plugin.analyze(compilation).then(() => {


### PR DESCRIPTION
Building on @tido64's great work in #133 this adds a few extra things:

- Add `ignoredPackages` to core + plugin ( @tido64 )
- Add `--ignored-packages|-i` CLI option
- Add regex option
- Update docs

@tido64 -- Can you review and see if you're good with the additional changes? And maybe kick the tires on the PR to make sure it works for your use case? Thanks! 🙏 