### PR TITLE
Replace chalk with picocolors

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,10 @@
     "check-ci": "yarn run lint && yarn run test-cov"
   },
   "dependencies": {
-    "chalk": "^4.1.0",
     "fp-ts": "^2.6.1",
     "io-ts": "^2.2.13",
     "io-ts-reporters": "^1.2.2",
+    "picocolors": "^1.0.0",
     "pify": "^5.0.0",
     "semver-compare": "^1.0.0",
     "yargs": "^16.2.0"
@@ -93,6 +93,7 @@
     "sinon": "^9.0.2",
     "sinon-chai": "^3.5.0",
     "source-map-support": "^0.5.19",
+    "strip-ansi": "^7.0.1",
     "ts-node": "^9.1.1",
     "tslint": "^6.1.2",
     "typescript": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "sinon": "^9.0.2",
     "sinon-chai": "^3.5.0",
     "source-map-support": "^0.5.19",
-    "strip-ansi": "^7.0.1",
+    "strip-ansi": "^6.0.1",
     "ts-node": "^9.1.1",
     "tslint": "^6.1.2",
     "typescript": "^4.1.3",

--- a/src/lib/actions/duplicates.ts
+++ b/src/lib/actions/duplicates.ts
@@ -1,4 +1,4 @@
-import * as chalk from "chalk";
+import * as colors from "picocolors";
 
 import { IActionModule, IModule, SYNTHETIC_SOURCE_TOKEN } from "../interfaces/modules";
 import { numF, sort } from "../util/strings";
@@ -208,7 +208,7 @@ class DuplicatesTemplate extends Template {
     return Promise.resolve()
       .then(() => this.action.getData() as Promise<IDuplicatesData>)
       .then(({ meta, assets }) => {
-        const dupAsset = (name: string) => chalk`{gray ## \`${name}\`}`;
+        const dupAsset = (name: string) => colors.gray(`## \`${name}\``);
         const dupFiles = (name: string) => Object.keys(assets[name].files)
           .map((baseName) => {
             const { files } = assets[name];
@@ -223,13 +223,13 @@ class DuplicatesTemplate extends Template {
               .map((sourceGroup, i) => this.trim(`
                 ${i}. (${inlineMeta(sourceGroup.meta)})
                   ${sourceGroup.modules
-                    .map((mod) => `(${mod.size.full}) ${chalk.gray(mod.fileName)}`)
+                    .map((mod) => `(${mod.size.full}) ${colors.gray(mod.fileName)}`)
                     .join("\n    ")}
               `, 14))
               .join("\n  ");
 
-            return this.trim(chalk`
-              * {green ${baseName}}
+            return this.trim(`
+              * ${colors.green(baseName)}
                 * Meta: ${inlineMeta(base.meta)}
                 ${sources}
             `, 14);
@@ -237,11 +237,11 @@ class DuplicatesTemplate extends Template {
           .join("\n");
         const duplicates = (name: string) => `${dupAsset(name)}\n${dupFiles(name)}\n`;
 
-        const report = this.trim(chalk`
-          {cyan inspectpack --action=duplicates}
-          {gray ===============================}
+        const report = this.trim(`
+          ${colors.cyan("inspectpack --action=duplicates")}
+          ${colors.gray("===============================")}
 
-          {gray ## Summary}
+          ${colors.gray("## Summary")}
           * Extra Files (unique):         ${numF(meta.extraFiles.num)}
           * Extra Sources (non-unique):   ${numF(meta.extraSources.num)}
           * Extra Bytes (non-unique):     ${numF(meta.extraSources.bytes)}

--- a/src/lib/actions/sizes.ts
+++ b/src/lib/actions/sizes.ts
@@ -1,4 +1,4 @@
-import * as chalk from "chalk";
+import * as colors from "picocolors";
 
 import { IActionModule } from "../interfaces/modules";
 import { numF, sort } from "../util/strings";
@@ -74,25 +74,25 @@ class SizesTemplate extends Template {
       .then(() => this.action.getData() as Promise<ISizesData>)
       .then(({ meta, assets }) => {
         const files = (mods: IActionModule[]) => mods
-          .map((obj) => this.trim(chalk`
-            * {gray ${obj.fileName}}
+          .map((obj) => this.trim(`
+            * ${colors.gray(obj.fileName)}
               * Size: ${numF(obj.size.full)}
           `, 12))
           .join("\n");
 
         const assetSizes = Object.keys(assets)
-          .map((name) => this.trim(chalk`
-            {gray ## \`${name}\`}
+          .map((name) => this.trim(`
+            ${colors.gray(`## \`${name}\``)}
             * Bytes: ${numF(assets[name].meta.full)}
             ${files(assets[name].files)}
           `, 12))
           .join("\n\n");
 
-        const report = this.trim(chalk`
-          {cyan inspectpack --action=sizes}
-          {gray ==========================}
+        const report = this.trim(`
+          ${colors.cyan("inspectpack --action=sizes")}
+          ${colors.gray("==========================")}
 
-          {gray ## Summary}
+          ${colors.gray("## Summary")}
           * Bytes: ${numF(meta.full)}
 
           ${assetSizes}

--- a/src/lib/actions/versions.ts
+++ b/src/lib/actions/versions.ts
@@ -1,4 +1,4 @@
-import * as chalk from "chalk";
+import * as colors from "picocolors";
 import { dirname, join, relative, sep } from "path";
 import semverCompare = require("semver-compare");
 
@@ -538,15 +538,15 @@ class VersionsTemplate extends Template {
     return Promise.resolve()
       .then(() => this.action.getData() as Promise<IVersionsData>)
       .then(({ meta, assets }) => {
-        const versAsset = (name: string) => chalk`{gray ## \`${name}\`}`;
+        const versAsset = (name: string) => colors.gray(`## \`${name}\``);
         const versPkgs = (name: string) => Object.keys(assets[name].packages)
           .sort(sort)
-          .map((pkgName) => this.trim(chalk`
-            * {cyan ${pkgName}}
+          .map((pkgName) => this.trim(`
+            * ${colors.cyan(pkgName)}
               ${Object.keys(assets[name].packages[pkgName])
                 .sort(semverCompare)
-                .map((version) => this.trim(chalk`
-                  * {gray ${version}}
+                .map((version) => this.trim(`
+                  * ${colors.gray(version)}
                     ${Object.keys(assets[name].packages[pkgName][version])
                       .sort(sort)
                       .map((filePath) => {
@@ -555,12 +555,12 @@ class VersionsTemplate extends Template {
                           modules,
                         } = assets[name].packages[pkgName][version][filePath];
 
-                        return this.trim(chalk`
-                        * {green ${shortPath(filePath)}}
+                        return this.trim(`
+                        * ${colors.green(shortPath(filePath))}
                           * Num deps: ${numF(skews.length)}, files: ${numF(modules.length)}
                           ${skews
                             .map((pkgParts) => pkgParts.map((part, i) => Object.assign({}, part, {
-                              name: chalk[i < pkgParts.length - 1 ? "gray" : "cyan"](part.name),
+                              name: colors[i < pkgParts.length - 1 ? "gray" : "cyan"](part.name),
                             })))
                             .map(pkgNamePath)
                             .sort(sort)
@@ -580,11 +580,11 @@ class VersionsTemplate extends Template {
           .join("\n");
         const versions = (name: string) => `${versAsset(name)}\n${versPkgs(name)}\n`;
 
-        const report = this.trim(chalk`
-          {cyan inspectpack --action=versions}
-          {gray =============================}
+        const report = this.trim(`
+          ${colors.cyan("inspectpack --action=versions")}
+          ${colors.gray("=============================")}
 
-          {gray ## Summary}
+          ${colors.gray("## Summary")}
           * Packages with skews:      ${numF(meta.packages.num)}
           * Total resolved versions:  ${numF(meta.resolved.num)}
           * Total installed packages: ${numF(meta.installed.num)}

--- a/src/lib/util/strings.ts
+++ b/src/lib/util/strings.ts
@@ -1,5 +1,5 @@
-import * as chalk from "chalk";
+import * as colors from "picocolors";
 
-export const numF = (val: string | number) => chalk.bold.cyan(val.toString());
+export const numF = (val: string | number) => colors.bold(colors.cyan(val.toString()));
 
 export const sort = (a: string, b: string) => a.localeCompare(b);

--- a/src/plugin/duplicates.ts
+++ b/src/plugin/duplicates.ts
@@ -1,4 +1,4 @@
-import * as chalk from "chalk";
+import * as colors from "picocolors";
 import semverCompare = require("semver-compare");
 import { actions } from "../lib";
 import { IDuplicatesData, IDuplicatesFiles } from "../lib/actions/duplicates";
@@ -52,10 +52,10 @@ interface IPackageNames {
 // ----------------------------------------------------------------------------
 // Helpers
 // ----------------------------------------------------------------------------
-const identical = (val: string) => chalk`{bold.magenta ${val}}`;
-const similar = (val: string) => chalk`{bold.blue ${val}}`;
-const warning = (val: string) => chalk`{bold.yellow ${val}}`;
-const error = (val: string) => chalk`{bold.red ${val}}`;
+const identical = (val: string) => colors.magenta(val);
+const similar = (val: string) => colors.blue(val);
+const warning = (val: string) => colors.yellow(val);
+const error = (val: string) => colors.red(val);
 
 // `~/different-foo/~/foo` + highlight last component.
 const shortPath = (filePath: string, pkgName: string) => {
@@ -64,7 +64,7 @@ const shortPath = (filePath: string, pkgName: string) => {
   // Color last part of package name.
   const lastPkgIdx = short.lastIndexOf(pkgName);
   if (lastPkgIdx > -1) {
-    short = chalk`${short.substring(0, lastPkgIdx)}{cyan ${pkgName}}`;
+    short = `${short.substring(0, lastPkgIdx)}${colors.cyan(pkgName)}`;
   }
 
   return short;
@@ -194,7 +194,7 @@ export const _getDuplicatesVersionsData = (
   if (extraSources !== foundSources) {
     addWarning(error(
       `Missing sources: Expected ${numF(extraSources)}, found ${numF(foundSources)}.\n` +
-      chalk`{white Found map:} {gray ${JSON.stringify(foundDupFilesMap)}}\n`,
+      `${colors.white("Found map:")} ${colors.gray(JSON.stringify(foundDupFilesMap))}\n`,
     ));
   }
 
@@ -249,12 +249,12 @@ export class DuplicatesPlugin {
     ])
       .then((datas) => {
         const [dupData, pkgDataOrig] = datas;
-        const header = chalk`{bold.underline Duplicate Sources / Packages}`;
+        const header = colors.bold(colors.underline("Duplicate Sources / Packages"));
 
         // No duplicates.
         if (dupData.meta.extraFiles.num === 0) {
           // tslint:disable no-console
-          console.log(chalk`\n${header} - {green No duplicates found. 🚀}\n`);
+          console.log(`\n${header} - ${colors.green("No duplicates found. 🚀")}\n`);
           return;
         }
 
@@ -266,11 +266,11 @@ export class DuplicatesPlugin {
 
         // Have duplicates. Report summary.
         // tslint:disable max-line-length
-        addMsg(chalk`${header} - ${fmt("Duplicates found! ⚠️")}
+        addMsg(`${header} - ${fmt("Duplicates found! ⚠️")}
 
-* {yellow.bold.underline Duplicates}: Found ${numF(dupData.meta.extraFiles.num)} ${similar("similar")} files across ${numF(dupData.meta.extraSources.num)} code sources (both ${identical("identical")} + similar)
+* ${colors.yellow(colors.bold(colors.underline("Duplicates")))}: Found ${numF(dupData.meta.extraFiles.num)} ${similar("similar")} files across ${numF(dupData.meta.extraSources.num)} code sources (both ${identical("identical")} + similar)
   accounting for ${numF(dupData.meta.extraSources.bytes)} bundled bytes.
-* {yellow.bold.underline Packages}: Found ${numF(pkgData.meta.packages.num)} packages with ${numF(pkgData.meta.resolved.num)} {underline resolved}, ${numF(pkgData.meta.installed.num)} {underline installed}, and ${numF(pkgData.meta.depended.num)} {underline depended} versions.
+* ${colors.yellow(colors.bold(colors.underline("Packages")))}: Found ${numF(pkgData.meta.packages.num)} packages with ${numF(pkgData.meta.resolved.num)} ${colors.underline("resolved")}, ${numF(pkgData.meta.installed.num)} ${colors.underline("installed")}, and ${numF(pkgData.meta.depended.num)} ${colors.underline("depended")} versions.
 `);
         // tslint:enable max-line-length
 
@@ -288,7 +288,7 @@ export class DuplicatesPlugin {
 
           // Only add asset name when duplicates.
           if (pkgNames.length) {
-            addMsg(chalk`{gray ## ${dupAssetName}}`);
+            addMsg(colors.gray(`## ${dupAssetName}`));
           }
 
           pkgNames.forEach((pkgName) => {
@@ -308,7 +308,7 @@ export class DuplicatesPlugin {
                 let installs = Object.keys(packages[pkgName][version]).map((installed) => {
                   const skews = packages[pkgName][version][installed].skews
                     .map((pkgParts) => pkgParts.map((part, i) => Object.assign({}, part, {
-                      name: chalk[i < pkgParts.length - 1 ? "gray" : "cyan"](part.name),
+                      name: colors[i < pkgParts.length - 1 ? "gray" : "cyan"](part.name),
                     })))
                     .map(pkgNamePath)
                     .sort(sort);
@@ -316,7 +316,7 @@ export class DuplicatesPlugin {
                   numPkgDepended += skews.length;
 
                   if (!verbose) {
-                    return chalk`  {green ${version}} {gray ${shortPath(installed, pkgName)}}
+                    return `  ${colors.green(version)} ${colors.gray(shortPath(installed, pkgName))}
     ${skews.join("\n    ")}`;
                   }
 
@@ -325,19 +325,19 @@ export class DuplicatesPlugin {
                     .filter(Boolean)
                     .map((mod) => {
                       const note = mod.isIdentical ? identical("I") : similar("S");
-                      return chalk`{gray ${mod.baseName}} (${note}, ${numF(mod.bytes)})`;
+                      return `${colors.gray(mod.baseName)} (${note}, ${numF(mod.bytes)})`;
                     });
 
-                  return chalk`    {gray ${shortPath(installed, pkgName)}}
-      {white * Dependency graph}
+                  return `    ${colors.gray(shortPath(installed, pkgName))}
+      ${colors.white("* Dependency graph")}
         ${skews.join("\n        ")}
-      {white * Duplicated files in }{gray ${dupAssetName}}
+      ${colors.white("* Duplicated files in ")}${colors.gray(dupAssetName)}
         ${duplicates.join("\n        ")}
 `;
                 });
 
                 if (verbose) {
-                  installs = [chalk`  {green ${version}}`].concat(installs);
+                  installs = [`  ${colors.green(version)}`].concat(installs);
                 }
 
                 return installs;
@@ -345,7 +345,7 @@ export class DuplicatesPlugin {
               .reduce((m, a) => m.concat(a), []); // flatten.
 
             // tslint:disable-next-line max-line-length
-            addMsg(chalk`{cyan ${pkgName}} (Found ${numF(numPkgResolved)} {underline resolved}, ${numF(numPkgInstalled)} {underline installed}, ${numF(numPkgDepended)} {underline depended}. Latest {green ${latestVersion || "NONE"}}.)`);
+            addMsg(`${colors.cyan(pkgName)} (Found ${numF(numPkgResolved)} ${colors.underline("resolved")}, ${numF(numPkgInstalled)} ${colors.underline("installed")}, ${numF(numPkgDepended)} ${colors.underline("depended")}. Latest ${colors.green(latestVersion || "NONE")}.)`);
             versions.forEach(addMsg);
 
             if (!verbose) {
@@ -354,10 +354,10 @@ export class DuplicatesPlugin {
           });
         });
         // tslint:disable max-line-length
-        addMsg(chalk`
-* {gray.bold.underline Understanding the report}: Need help with the details? See:
+        addMsg(`
+* ${colors.gray(colors.bold(colors.underline("Understanding the report")))}: Need help with the details? See:
   https://github.com/FormidableLabs/inspectpack/#diagnosing-duplicates
-* {gray.bold.underline Fixing bundle duplicates}: An introductory guide:
+* ${colors.gray(colors.bold(colors.underline("Fixing bundle duplicates")))}: An introductory guide:
   https://github.com/FormidableLabs/inspectpack/#fixing-bundle-duplicates
 `.trimLeft());
         // tslint:enable max-line-length

--- a/test/bin/inspectpack.spec.ts
+++ b/test/bin/inspectpack.spec.ts
@@ -7,7 +7,7 @@ const SIMPLE_STATS = require.resolve("../fixtures/simple/dist-development-5/stat
 const DUP_ESM_STATS = require.resolve("../fixtures/duplicates-esm/dist-development-5/stats.json");
 
 const exec = (args: string[]) => execa("node", [IP_PATH].concat(args), {
-  env: { ...process.env, FORCE_COLOR: "0" }
+  env: { ...process.env, NO_COLOR: "true" }
 });
 
 describe("bin/inspectpack", () => {

--- a/test/fixtures/packages/check-bundle.js
+++ b/test/fixtures/packages/check-bundle.js
@@ -3,7 +3,7 @@
 const { stat } = require("fs");
 const { resolve, join } = require("path");
 
-const chalk = require("chalk");
+const colors = require("picocolors");
 const pify = require("pify");
 
 /**
@@ -26,7 +26,7 @@ if (!WEBPACK_VERSION) {
 
 const main = () => {
   const fixture = `${WEBPACK_CWD}/dist-${WEBPACK_MODE}-${WEBPACK_VERSION}/bundle.js`;
-  log(chalk `\n[{yellow.bold Checking fixture}] ${fixture}\n`);
+  log(`\n[${colors.yellow(colors.bold("Checking fixture"))}] ${fixture}\n`);
 
   const fixturePath = resolve(join(__dirname, ".."), fixture);
   return exists(fixturePath)
@@ -39,6 +39,6 @@ const main = () => {
 
 main()
   .catch((err) => {
-    log(chalk `\n[{red.bold Missing fixture}] ${err.message}\n`);
+    log(`\n[${colors.red(colors.bold("Missing fixture"))}] ${err.message}\n`);
     process.exit(1);
   });

--- a/test/fixtures/packages/webpack.js
+++ b/test/fixtures/packages/webpack.js
@@ -1,5 +1,5 @@
 const { dirname } = require("path");
-const chalk = require("chalk");
+const colors = require("picocolors");
 
 /**
  * Runtime switcher for all webpack versions.
@@ -12,7 +12,7 @@ if (!WEBPACK_VERSION) {
 }
 
 const fixture = `${WEBPACK_CWD}/dist-${WEBPACK_MODE}-${WEBPACK_VERSION}/bundle.js`;
-log(chalk `\n[{green.bold Building fixture}] ${fixture}\n`);
+log(`\n[${colors.green(colors.bold("Building fixture"))}] ${fixture}\n`);
 
 // Change process directory to the actual install, so that node_modules
 // resolution will use the nested stuff **first**.

--- a/test/lib/actions/duplicates.spec.ts
+++ b/test/lib/actions/duplicates.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from "chai";
-import * as chalk from "chalk";
 import { join, sep } from "path";
 
 import { IAction, TemplateFormat } from "../../../src/lib/actions/base";
@@ -327,18 +326,6 @@ describe("lib/actions/duplicates", () => {
   });
 
   describe("text", () => {
-    let origChalkLevel: chalk.Level;
-
-    beforeEach(() => {
-      // Stash and disable chalk for tests.
-      origChalkLevel = chalk.level;
-      (chalk as any).level = 0;
-    });
-
-    afterEach(() => {
-      (chalk as any).level = origChalkLevel;
-    });
-
     it("displays duplicates correctly for scoped packages", () => {
       return scopedInstance.template.text()
         .then((textStr) => {

--- a/test/lib/actions/sizes.spec.ts
+++ b/test/lib/actions/sizes.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from "chai";
-import * as chalk from "chalk";
 import { join, resolve } from "path";
 
 import { IAction, IModulesByAsset, TemplateFormat } from "../../../src/lib/actions/base";
@@ -563,17 +562,6 @@ describe("lib/actions/sizes", () => {
   });
 
   describe("text", () => {
-    let origChalkLevel: chalk.Level;
-
-    beforeEach(() => {
-      // Stash and disable chalk for tests.
-      origChalkLevel = chalk.level;
-      (chalk as any).level = 0;
-    });
-
-    afterEach(() => {
-      (chalk as any).level = origChalkLevel;
-    });
 
     it("displays sizes correctly for scoped packages", () => {
       return scopedInstance.template.text()

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -1,7 +1,7 @@
 import { join, resolve, sep } from "path";
 
 import { expect } from "chai";
-import stripAnsi from "strip-ansi";
+import stripAnsi = require("strip-ansi");
 import * as merge from "deepmerge";
 import * as mock from "mock-fs";
 

--- a/test/lib/actions/versions.spec.ts
+++ b/test/lib/actions/versions.spec.ts
@@ -1,7 +1,7 @@
 import { join, resolve, sep } from "path";
 
 import { expect } from "chai";
-import * as chalk from "chalk";
+import stripAnsi from "strip-ansi";
 import * as merge from "deepmerge";
 import * as mock from "mock-fs";
 
@@ -854,18 +854,6 @@ describe("lib/actions/versions", () => {
   });
 
   describe("text", () => {
-    let origChalkLevel: chalk.Level;
-
-    beforeEach(() => {
-      // Stash and disable chalk for tests.
-      origChalkLevel = chalk.level;
-      (chalk as any).level = 0;
-    });
-
-    afterEach(() => {
-      (chalk as any).level = origChalkLevel;
-    });
-
     it("displays versions skews correctly for scoped packages", () => {
       mock({
         "test/fixtures/scoped": fixtureDirs["test/fixtures/scoped"],
@@ -873,7 +861,7 @@ describe("lib/actions/versions", () => {
 
       return scopedInstance.template.text()
         .then((textStr) => {
-          expect(textStr).to.eql(`
+          expect(stripAnsi(textStr)).to.eql(`
 inspectpack --action=versions
 =============================
 
@@ -915,7 +903,7 @@ inspectpack --action=versions
 
       return multipleRootsInstance.template.text()
         .then((textStr) => {
-          expect(textStr).to.eql(`
+          expect(stripAnsi(textStr)).to.eql(`
 inspectpack --action=versions
 =============================
 
@@ -951,7 +939,7 @@ inspectpack --action=versions
 
       return hiddenAppRootsInstance.template.text()
         .then((textStr) => {
-          expect(textStr).to.eql(`
+          expect(stripAnsi(textStr)).to.eql(`
 inspectpack --action=versions
 =============================
 
@@ -986,7 +974,7 @@ inspectpack --action=versions
       return scopedInstance.template.tsv()
         .then((tsvStr) => {
           /*tslint:disable max-line-length*/
-          expect(tsvStr).to.eql(`
+          expect(stripAnsi(tsvStr)).to.eql(`
 Asset	Package	Version	Installed Path	Dependency Path
 bundle.js	@scope/foo	1.1.1	~/@scope/foo	scoped@1.2.3 -> @scope/foo@^1.0.9
 bundle.js	@scope/foo	1.1.1	~/@scope/foo	scoped@1.2.3 -> flattened-foo@^1.1.0 -> @scope/foo@^1.1.1
@@ -1007,7 +995,7 @@ bundle.js	foo	4.3.3	~/unscoped-foo/~/deeper-unscoped/~/foo	scoped@1.2.3 -> unsco
       return hiddenAppRootsInstance.template.tsv()
         .then((tsvStr) => {
           /*tslint:disable max-line-length*/
-          expect(tsvStr).to.eql(`
+          expect(stripAnsi(tsvStr)).to.eql(`
 Asset	Package	Version	Installed Path	Dependency Path
 bundle.js	foo	1.1.1	~/foo	package1@1.1.1 -> foo@^1.0.0
 bundle.js	foo	3.3.3	~/different-foo/~/foo	package1@1.1.1 -> different-foo@^1.0.1 -> foo@^3.0.1

--- a/test/lib/plugin/duplicates.spec.ts
+++ b/test/lib/plugin/duplicates.spec.ts
@@ -257,7 +257,7 @@ foo (Found 1 resolved, 2 installed, 2 depended. Latest 1.1.1.)
                 .to.have.lengthOf(1).and
                 .to.have.property("0").that
                 .is.an("Error");
-              expect(stripAnsi(compilation.warnings[0].message)).to.eql(defaultReport);
+              expect(stripAnsi(compilation.errors[0].message)).to.eql(defaultReport);
             });
           });
 
@@ -273,7 +273,7 @@ foo (Found 1 resolved, 2 installed, 2 depended. Latest 1.1.1.)
                 .to.have.lengthOf(1).and
                 .to.have.property("0").that
                 .is.an("Error");
-              expect(stripAnsi(compilation.warnings[0].message)).to.eql(verboseReport);
+              expect(stripAnsi(compilation.errors[0].message)).to.eql(verboseReport);
             });
           });
 

--- a/test/lib/plugin/duplicates.spec.ts
+++ b/test/lib/plugin/duplicates.spec.ts
@@ -15,7 +15,7 @@ import {
    ICompilation,
 } from "../../../src/plugin/duplicates";
 
-import stripAnsi from "strip-ansi";
+import stripAnsi = require("strip-ansi");
 import { IWebpackStats } from "../../../src/lib/interfaces/webpack-stats";
 import { toPosixPath } from "../../../src/lib/util/files";
 import { IFixtures, loadFixtures, VERSIONS } from "../../utils";

--- a/test/lib/plugin/duplicates.spec.ts
+++ b/test/lib/plugin/duplicates.spec.ts
@@ -15,7 +15,7 @@ import {
    ICompilation,
 } from "../../../src/plugin/duplicates";
 
-import * as chalk from "chalk";
+import stripAnsi from "strip-ansi";
 import { IWebpackStats } from "../../../src/lib/interfaces/webpack-stats";
 import { toPosixPath } from "../../../src/lib/util/files";
 import { IFixtures, loadFixtures, VERSIONS } from "../../utils";
@@ -217,17 +217,6 @@ foo (Found 1 resolved, 2 installed, 2 depended. Latest 1.1.1.)
         });
 
         describe(`v${vers}`, () => {
-          let origChalkLevel: chalk.Level;
-
-          beforeEach(() => {
-            // Stash and disable chalk for tests.
-            origChalkLevel = chalk.level;
-            (chalk as any).level = 0;
-          });
-
-          afterEach(() => {
-            (chalk as any).level = origChalkLevel;
-          });
 
           it(`produces a default report`, () => {
             const plugin = new DuplicatesPlugin({});
@@ -237,8 +226,8 @@ foo (Found 1 resolved, 2 installed, 2 depended. Latest 1.1.1.)
               expect(compilation.warnings)
                 .to.have.lengthOf(1).and
                 .to.have.property("0").that
-                  .is.an("Error").and
-                  .has.property("message", defaultReport);
+                  .is.an("Error");
+              expect(stripAnsi(compilation.warnings[0].message)).to.eql(defaultReport);
             });
           });
 
@@ -252,8 +241,8 @@ foo (Found 1 resolved, 2 installed, 2 depended. Latest 1.1.1.)
               expect(compilation.warnings)
                 .to.have.lengthOf(1).and
                 .to.have.property("0").that
-                  .is.an("Error").and
-                  .has.property("message", verboseReport);
+                  .is.an("Error");
+              expect(stripAnsi(compilation.warnings[0].message)).to.eql(verboseReport);
             });
           });
 
@@ -267,8 +256,8 @@ foo (Found 1 resolved, 2 installed, 2 depended. Latest 1.1.1.)
               expect(compilation.errors)
                 .to.have.lengthOf(1).and
                 .to.have.property("0").that
-                  .is.an("Error").and
-                  .has.property("message", defaultReport);
+                .is.an("Error");
+              expect(stripAnsi(compilation.warnings[0].message)).to.eql(defaultReport);
             });
           });
 
@@ -283,8 +272,8 @@ foo (Found 1 resolved, 2 installed, 2 depended. Latest 1.1.1.)
               expect(compilation.errors)
                 .to.have.lengthOf(1).and
                 .to.have.property("0").that
-                  .is.an("Error").and
-                  .has.property("message", verboseReport);
+                .is.an("Error");
+              expect(stripAnsi(compilation.warnings[0].message)).to.eql(verboseReport);
             });
           });
 
@@ -301,7 +290,7 @@ foo (Found 1 resolved, 2 installed, 2 depended. Latest 1.1.1.)
 
               // First call, first argument is the report
               const actualReport = emitHandler.args[0][0];
-              expect(actualReport).to.eql(defaultReport);
+              expect(stripAnsi(actualReport)).to.eql(defaultReport);
             });
           });
 
@@ -319,7 +308,7 @@ foo (Found 1 resolved, 2 installed, 2 depended. Latest 1.1.1.)
 
               // First call, first argument is the report
               const actualReport = emitHandler.args[0][0];
-              expect(actualReport).to.eql(verboseReport);
+              expect(stripAnsi(actualReport)).to.eql(verboseReport);
             });
           });
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,4 +1,5 @@
 import { basename, join, relative, sep } from "path";
+import stripAnsi from "strip-ansi";
 
 import { IModule } from "../src/lib/interfaces/modules";
 import { IWebpackStats } from "../src/lib/interfaces/webpack-stats";
@@ -223,7 +224,7 @@ const REMAINDER_IDX = 7; // Everything after.
 // - shorten, make relative, and posixify test paths
 // - replace numbers of byte sizes with `"NUM"` since Windows has different
 //   byte counts.
-export const normalizeOutput = (re: RegExp, str: string) => str
+export const normalizeOutput = (re: RegExp, str: string) => stripAnsi(str)
   // Normalize any string paths.
   .replace(re, function() { // tslint:disable-line only-arrow-functions
     return [

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,5 @@
 import { basename, join, relative, sep } from "path";
-import stripAnsi from "strip-ansi";
+import stripAnsi = require("strip-ansi");
 
 import { IModule } from "../src/lib/interfaces/modules";
 import { IWebpackStats } from "../src/lib/interfaces/webpack-stats";

--- a/yarn.lock
+++ b/yarn.lock
@@ -844,10 +844,10 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
-ansi-regex@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
-  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
@@ -5872,12 +5872,12 @@ strip-ansi@^6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
-strip-ansi@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.0.1.tgz#61740a08ce36b61e50e65653f07060d000975fb2"
-  integrity sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
-    ansi-regex "^6.0.1"
+    ansi-regex "^5.0.1"
 
 strip-bom@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -844,6 +844,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-regex@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
+  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
+
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -1409,7 +1414,7 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.3.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -4902,6 +4907,11 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
@@ -5861,6 +5871,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.0.1.tgz#61740a08ce36b61e50e65653f07060d000975fb2"
+  integrity sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==
+  dependencies:
+    ansi-regex "^6.0.1"
 
 strip-bom@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Hi,

I'm trying to reduce the size of the dependencies in my dependencies.

`chalk` is a quite big library, and `picocolors` is much smaller and more performant.

I tried hard to get the tests running locally and made sure the ones that can run are running fine, but I have these errors:

```
❯ yarn test
yarn run v1.17.3
$ builder concurrent --buffer test-bin test-lib

TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /Users/onigoetz/Sites/Libs/inspectpack/test/lib/actions/duplicates.spec.ts
    at Loader.defaultGetFormat [as _getFormat] (internal/modules/esm/get_format.js:65:15)
    at Loader.getFormat (internal/modules/esm/loader.js:116:42)
    at Loader.getModuleJob (internal/modules/esm/loader.js:247:31)
    at Loader.import (internal/modules/esm/loader.js:181:17)
    at Object.exports.loadFilesAsync (/Users/onigoetz/Sites/Libs/inspectpack/node_modules/mocha/lib/esm-utils.js:33:20)
    at singleRun (/Users/onigoetz/Sites/Libs/inspectpack/node_modules/mocha/lib/cli/run-helpers.js:125:3)
    at Object.exports.handler (/Users/onigoetz/Sites/Libs/inspectpack/node_modules/mocha/lib/cli/run.js:362:5)


  bin/inspectpack
    - needs more tests
    -h
      ✓ displays help by default with error exit (145ms)
      ✓ displays help with flag with normal exit (106ms)
    --bail
      ✓ passes on simple sizes (117ms)
      ✓ passes on simple duplicates (109ms)
      ✓ passes on simple versions (110ms)
      ✓ passes on duplicates-esm sizes (115ms)
      ✓ bails on duplicates-esm duplicates (113ms)
      ✓ bails on duplicates-esm versions (123ms)

  bin/lib/args
    - needs tests


  8 passing (947ms)
  2 pending

[builder:finish] Hit 2 errors: 
  * Error: Command failed: sh -c mocha "test/lib/**/*.spec.ts"

  * Error: Command failed: sh -c mocha "test/lib/**/*.spec.ts"

[builder:builder-core:end:19718] Task: concurrent test-bin, test-lib, Error: Command failed: sh -c mocha "test/lib/**/*.spec.ts"

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

On another topic, I see that `fp-ts` is really a big dependency too, I would like to make a PR to replace it with something else if you'd be interested in that ? I'm not sure exactly what `fp-ts` brings though.